### PR TITLE
 fix: temporarily use single threaded for cargo test in CI #56 

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -101,6 +101,10 @@ jobs:
         if: needs.rust_skip.outputs.should_skip != 'true'
         with:
           command: test
+          # Using a single thread to run tests to avoid hitting limitations on runner.
+          # We should investigate cpu/memory usage and upgrade runner size accordingly
+          # and/or reduce cpu/memory usage in our tests.
+          # https://github.com/actions/runner-images/issues/6680
           args:  --all-features -- --nocapture --quiet --test-threads=1
 
       # Run a build. The earlier test compile won't have built the executables.


### PR DESCRIPTION
Seems other people are seeing this issue more frequently as well - https://github.com/actions/runner-images/issues/6680

For now, reducing cargo test to a single thread seems to solve the issue. We could update to larger runners and/or reduce our cpu/memory usage in tests, but this should get our current PRs unblocked at the cost of slower CI