### PR TITLE
fix: add missing v in release drafter

### DIFF
--- a/.github/release-drafter-engine.yml
+++ b/.github/release-drafter-engine.yml
@@ -1,7 +1,7 @@
 _extends: kaskada:.github/release-drafter.yml
 
 name-template: Engine $RESOLVED_VERSION
-tag-template: engine@$RESOLVED_VERSION
+tag-template: engine@v$RESOLVED_VERSION
 tag-prefix: engine@
 
 # Only include PRs with one of these labels


### PR DESCRIPTION
This should fix the github release template to include the expected `v` in front of the version for the workflow to trigger when publishing a release. 