### PR TITLE
ci: use ubuntu 20.04 for engine builds and release

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -34,7 +34,7 @@ jobs:
   rust_skip:
     name: Rust Skip Duplicates
     continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -50,7 +50,7 @@ jobs:
 
   rust_check:
     name: Rust Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [rust_skip]
     steps:
       - name: Checkout sources
@@ -172,7 +172,7 @@ jobs:
   # that waiting to determine if we *should* skip it would be a waste.
   rust_format:
     name: Rust Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -197,7 +197,7 @@ jobs:
   # that waiting to determine if we *should* skip it would be a waste.
   rust_audit:
     name: Rust Audits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Audits don't need a toolchain or any of the dependencies, so we don't cache.
     # Restoring the cache takes 2m. Running `cargo deny` takes 10s.

--- a/.github/workflows/ci_wren.yml
+++ b/.github/workflows/ci_wren.yml
@@ -25,7 +25,7 @@ jobs:
   wren_skip:
     name: Wren Skip Duplicates
     continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -43,7 +43,7 @@ jobs:
     name: Build and Unit Test Wren
     needs: [wren_skip]
     if: needs.wren_skip.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/release_engine.yml
+++ b/.github/workflows/release_engine.yml
@@ -84,7 +84,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             goos: linux
             goarch: amd64
-            host: ubuntu-latest
+            host: ubuntu-20.04
           - target: x86_64-pc-windows-msvc
             goos: windows
             goarch: amd64


### PR DESCRIPTION
Flip to using ubuntu 20.04 to build with the oldest, ubuntu stable libc version (Google Collab uses 20.04 which is a use case) 


