### PR TITLE
Update Dockerfile.release to use debiab bullseye

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN  apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates wget \


### PR DESCRIPTION
We build against libc version 2.31 and we need the image we are going to run our binaries to be at least 2.31. For debian that is bullseye (which is the version used to build Ubuntu 20.04)