### PR TITLE
allow openssl with sec vuln

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -58,7 +58,11 @@ ignore = [
     #
     # Not used in runtime code.
     # https://github.com/bheisler/criterion.rs/issues/629
-    "RUSTSEC-2021-0145"
+    "RUSTSEC-2021-0145",
+    # Denial of service in openssl.
+    # Since fixed, but waiting on dependencies to update. 
+    # https://github.com/sfackler/rust-openssl/pull/1854
+    "RUSTSEC-2023-0024"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
Long-term fix: our dependencies that pull in openssl (pulsar, reqwest) need to update, and we need to update them.

Short-term fix:
I don’t think we want to mess with removing those dependencies now. Rather would accept the vulnerability for now given the non-prod state of our system, and explicitly allow openssl

Job failure: https://github.com/kaskada-ai/kaskada/actions/runs/4510764637/jobs/7942099545