### PR TITLE
(ci): fixes name path and git safe directory

### DIFF
--- a/.github/workflows/reusable_ci_arm64_release.yml
+++ b/.github/workflows/reusable_ci_arm64_release.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Add artifacts to release
         if: startsWith(github.ref, 'refs/tags/engine@v')
         run: |
+          git config --global --add safe.directory '*'
           cp release/wren  ${WREN_ASSET_NAME}
           gh release upload ${TAG} ${WREN_ASSET_NAME} --clobber
         shell: bash
@@ -209,7 +210,7 @@ jobs:
       - name: Add artifacts to release
         if: startsWith(github.ref, 'refs/tags/engine@v')
         run: |
-          cp release/sparrow-main ${ENGINE_ASSET_NAME}
+          cp target/aarch64-unknown-linux-gnu/release/sparrow-main ${ENGINE_ASSET_NAME}
           gh release upload ${TAG} ${ENGINE_ASSET_NAME} --clobber
         shell: bash
         env:


### PR DESCRIPTION

* Had the wrong path for pushing sparrow binary 
* `gh` command validates safe directories and due to running from inside a container on a runner we need to authorize the directory. 