### PR TITLE
(ci): build and release kaskada CLI

### DIFF
--- a/.github/workflows/release_engine.yml
+++ b/.github/workflows/release_engine.yml
@@ -124,7 +124,9 @@ jobs:
         working-directory: wren
 
       - name: Wren - Copy NOTICE
-        run: cp NOTICE ./wren/
+        run: |
+          cp NOTICE ./wren/
+          cp NOTICE ./clients/cli
 
       - name: Apt Packages (Linux)
         if: matrix.goos == 'linux'
@@ -144,6 +146,17 @@ jobs:
           CXX: ${{ matrix.cxx }}
           CC: ${{ matrix.cc }}
         working-directory: wren
+
+      - name: CLI - Build
+        run: |
+          go build -ldflags="-w -s" -o ../release/cli${{ matrix.exe }} main.go
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          GOOS: ${{ matrix.goos }}
+          CGO_ENABLED: 1
+          CXX: ${{ matrix.cxx }}
+          CC: ${{ matrix.cc }}
+        working-directory: clients/cli
 
       - name: Sparrow - Install toolchain
         id: toolchain
@@ -177,6 +190,7 @@ jobs:
           path: |
             release/sparrow-main${{ matrix.exe }}
             release/wren${{ matrix.exe }}
+            release/cli${{ matrix.exe }}
 
       - name: Add artifacts to release
         if: startsWith(github.ref, 'refs/tags/engine@v')
@@ -185,6 +199,8 @@ jobs:
           gh release upload ${TAG} ${ENGINE_ASSET_NAME} --clobber
           cp release/wren${{ matrix.exe }} ${WREN_ASSET_NAME}
           gh release upload ${TAG} ${WREN_ASSET_NAME} --clobber
+          cp release/cli${{ matrix.exe }} ${CLI_ASSET_NAME}
+          gh release upload ${TAG} ${CLI_ASSET_NAME} --clobber
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -193,6 +209,7 @@ jobs:
           # so can have a stable link to the latest asset.
           ENGINE_ASSET_NAME: kaskada-engine-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.exe }}
           WREN_ASSET_NAME: kaskada-manager-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.exe }}
+          CLI_ASSET_NAME: kaskada-cli-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.exe }}
 
   release_docker_images:
     name: Build and push Docker images for releases

--- a/.github/workflows/reusable_ci_arm64_release.yml
+++ b/.github/workflows/reusable_ci_arm64_release.yml
@@ -113,7 +113,9 @@ jobs:
         working-directory: wren
 
       - name: Wren - Copy NOTICE
-        run: cp NOTICE ./wren/
+        run: | 
+          cp NOTICE ./wren/
+          cp NOTICE ./clients/cli
 
       ## Deviation: Grab the names for cross compiler and linker from inside the docker container
       - name: Set variables for cross compiler and linker
@@ -125,9 +127,19 @@ jobs:
       - name: Wren - Build
         run: |
           mkdir ../release/
-          set
           go build -ldflags="-w -s" -o ../release/wren main.go
         working-directory: wren
+        env:
+          CGO_ENABLED: 1
+          GOOS: linux
+          GOARCH: arm64
+          CC: ${{ steps.vars.outputs.cc }}
+          CXX: ${{ steps.vars.outputs.cxx }}
+
+      - name: CLI - Build
+        run: |
+          go build -ldflags="-w -s" -o ../release/cli main.go
+        working-directory: clients/cli
         env:
           CGO_ENABLED: 1
           GOOS: linux
@@ -142,12 +154,15 @@ jobs:
           retention-days: 5
           path: |
             release/wren
+            release/cli
 
       - name: Add artifacts to release
         if: startsWith(github.ref, 'refs/tags/engine@v')
         run: |
           cp release/wren  ${WREN_ASSET_NAME}
           gh release upload ${TAG} ${WREN_ASSET_NAME} --clobber
+          cp release/cli  ${CLI_ASSET_NAME}
+          gh release upload ${TAG} ${CLI_ASSET_NAME} --clobber
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -155,6 +170,7 @@ jobs:
           # Name of the assets to produce. We don't include the version
           # so can have a stable link to the latest asset.
           WREN_ASSET_NAME: kaskada-manager-linux-aarch64
+          CLI_ASSET_NAME: kaskada-cli-linux-aarch64
 
   sparrow_cross_amd64_arm64:
     runs-on: ubuntu-20.04

--- a/Dockerfile.release.dockerignore
+++ b/Dockerfile.release.dockerignore
@@ -2,5 +2,7 @@
 !run.sh
 !release/linux/amd64/sparrow-main
 !release/linux/amd64/wren
+!release/linux/amd64/cli
 !release/linux/arm64/sparrow-main
 !release/linux/arm64/wren
+!release/linux/arm64/cli


### PR DESCRIPTION
* Adds a build for the CLI to all supported OS/ARCH combinations 
* Pushes CLI binaries to GitHub release

 