### PR TITLE
Reverts builds on ubuntu 22.04

### DIFF
--- a/.github/workflows/release_engine.yml
+++ b/.github/workflows/release_engine.yml
@@ -90,10 +90,10 @@ jobs:
             goos: linux
             goarch: amd64
             host: ubuntu-20.04
-          - target: x86_64-unknown-linux-gnu
-            goos: linux
-            goarch: amd64
-            host: ubuntu-22.04
+          # - target: x86_64-unknown-linux-gnu
+          #   goos: linux
+          #   goarch: amd64
+          #   host: ubuntu-22.04
           - target: x86_64-pc-windows-msvc
             goos: windows
             goarch: amd64
@@ -211,9 +211,9 @@ jobs:
           TAG: ${{ github.ref_name }}
           # Name of the assets to produce. We don't include the version
           # so can have a stable link to the latest asset.
-          ENGINE_ASSET_NAME: kaskada-engine-${{ matrix.goos }}-${{ matrix.host }}-${{ matrix.goarch }}${{ matrix.exe }}
-          WREN_ASSET_NAME: kaskada-manager-${{ matrix.goos }}-${{ matrix.host }}-${{ matrix.goarch }}${{ matrix.exe }}
-          CLI_ASSET_NAME: kaskada-cli-${{ matrix.goos }}-${{ matrix.host }}-${{ matrix.goarch }}${{ matrix.exe }}
+          ENGINE_ASSET_NAME: kaskada-engine-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.exe }}
+          WREN_ASSET_NAME: kaskada-manager-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.exe }}
+          CLI_ASSET_NAME: kaskada-cli-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.exe }}
 
   # Not building docker image for ubuntu 22.04 (libc 2.35 libssl 3.0) 
   # See https://github.com/cross-rs/cross/pull/973 on the cross repo 


### PR DESCRIPTION
Reverting because it breaks the client download due to name change of the binary. Will apply it later once I have the client code ready as well. 