### PR TITLE
marked the pulsar auth_params field as sensitive

### DIFF
--- a/proto/kaskada/kaskada/v1alpha/pulsar.proto
+++ b/proto/kaskada/kaskada/v1alpha/pulsar.proto
@@ -3,6 +3,7 @@ package kaskada.kaskada.v1alpha;
 
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
+import "kaskada/kaskada/v1alpha/options.proto";
 
 message PulsarConfig {
   // The Pulsar protocol URL for the cluster.
@@ -21,7 +22,7 @@ message PulsarConfig {
 
   // Authentication parameters.
   // e.g. "token:xxx"
-  string auth_params = 4;
+  string auth_params = 4 [(kaskada.v1alpha.sensitive) = true];
 
   // A custom certificate chain to authenticate the server in TLS connections.
   string certificate_chain = 5;


### PR DESCRIPTION
in wren, this will automatically redact the field in protobuf object logs.

related to discussion #187