### PR TITLE
(docs): Update hello-world-cli.adoc

### DIFF
--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -158,7 +158,7 @@ curl -L "https://drive.google.com/uc?export=download&id=1SLdIw9uc0RGHY-eKzS30UBh
 
 ./kaskada-cli load \
     --table Purchase \
-    --file-path file:///${PWD}/purchase.parquet
+    --file-path file://${PWD}/purchase.parquet
 ----
 
 The file's content is added to the table.


### PR DESCRIPTION
We need 2 slashes for path argument. 
Though more than 2 still work (Unix systems behave the same no matter the number of leading slashes on a full path) 2 is the requirement for our implementation of CLI (Wren)