### PR TITLE
Updates from second trial

### DIFF
--- a/clients/python/src/kaskada/api/session.py
+++ b/clients/python/src/kaskada/api/session.py
@@ -199,10 +199,14 @@ class LocalBuilder(Builder):
         engine_cmd = [engine_binary_path, engine_command]
         logger.debug(f"Engine start command: {engine_cmd}")
         logger.info("Initializing manager process")
+        logger.info("Logging manager STDOUT to {manager_std_out}")
+        logger.info("Logging manager STDERR to {manager_std_err}")
         manager_process = api_utils.run_subprocess(
             manager_cmd, manager_std_err, manager_std_out
         )
         logger.info("Initializing engine process")
+        logger.info("Logging engine STDOUT to {engine_std_out}")
+        logger.info("Logging engine STDERR to {engine_std_err}")
         engine_process = api_utils.run_subprocess(
             engine_cmd, engine_std_err, engine_std_out
         )

--- a/clients/python/src/kaskada/client.py
+++ b/clients/python/src/kaskada/client.py
@@ -159,11 +159,9 @@ def get_client(client: Optional[Client] = None) -> Client:
         Client: The provided client argument or the global client.
     """
     if client is None and KASKADA_DEFAULT_CLIENT is None:
-        raise ValueError("Client must be provided")
+        raise ValueError("No client was provided, and no global client is configured. Consider setting the global client by creating a session, for example 'kaskada.api.session.LocalBuilder().build()`.")
     elif client is None:
         client = KASKADA_DEFAULT_CLIENT
 
-    if client is None:
-        raise ValueError("Client must be provided")
     validate_client(client)
     return client

--- a/docs-src/modules/ROOT/pages/installing.adoc
+++ b/docs-src/modules/ROOT/pages/installing.adoc
@@ -18,7 +18,7 @@ If you do have `pip3` replace `pip` with `pip3` in your command, i.e., `pip3 ins
 Kaskada is now installed. Kaskada can be used locally by creating a local session.
 
 .Creating a local Kaskada session in Python
-[.python]
+[source,python]
 ----
 from kaskada.api.session import LocalBuilder
 session = LocalBuilder().build()
@@ -38,7 +38,7 @@ Kaskada's python library includes notebook customizations that allow us to write
 We need to enable these customizations first before we can use them. 
 
 .Enable fenlmagic in this notebook 
-[,python]
+[source,ipython]
 ----
 %load_ext fenlmagic
 ----

--- a/docs-src/modules/ROOT/pages/loading-data.adoc
+++ b/docs-src/modules/ROOT/pages/loading-data.adoc
@@ -1,11 +1,10 @@
-= Loading Data 
+= Loading Data into a Table
 
 Kaskada stores data in _tables_. Tables consist of multiple rows, and
 each row is a value of the same type.
 The xref:developing:tables.adoc[Tables] section of the reference docs has more information about managing tables.
 
 [IMPORTANT]
-.Data must be loaded into a table
 ====
 A table must be created before data can be loaded into it.
 ====
@@ -20,18 +19,22 @@ Additionally, it expects the following:
 
 * The `time_column` (and all other date-time columns in your dataset)
 should be a type that can be xref:fenl:data-model.adoc#type-coercion[cast] to a xref:fenl:data-model.adoc#scalars[timestamp], for example an integer or RFC3330-formatted string.
-* If `subsort_id` is defined, the combination of the `group_column` (entity id), `time_column` and `subsort_column` should guarantee that each row is unique.  
+* If a subsort column is defined, the combination of the entity key column, time column and subsort column should guarantee that each row is unique.  
 
-=== Loading data from Parquet files
+=== Loading data from Parquet files into a table
 
 Events stored as a Parquet file can be loaded into a table by providing the file's xref:#File Location[location].
 The given location must be accessible to the Kaskada instance you wish to load the file into.
 
 .Loading a Parquet file using Python
-[source,Python]
+[source,python]
 ----
 from kaskada import table
-table.load_file(
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
+table.load(
   table_name = "Purchase",
   file = "file:///path/to/file.parquet", 
 )
@@ -46,13 +49,7 @@ kaskada-cli load \
     --file-type parquet
 ----
 
-[TIP]
-.Parquet version requirements
-====
-The Kaskada compute engine expects uploaded file data to be either CSV or parquet version 2. 
-====
-
-=== Loading data from CSV files
+=== Loading data from CSV files into a table
 
 Events stored as a CSV file can be loaded into a table by providing the file's xref:#File Location[location].
 The given location must be accessible to the Kaskada instance you wish to load the file into.
@@ -62,10 +59,14 @@ CSV type inference occurs when data is loaded.
 The schema is inferred by reading the first 1000 rows.
 
 .Loading a CSV file using Python
-[source,Python]
+[source,python]
 ----
 from kaskada import table
-table.load_file(
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
+table.load(
   table_name = "Purchase",
   file = "file:///path/to/file.csv", 
 )
@@ -107,16 +108,19 @@ The following environment variables are used to configure credentials:
 * `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
 * `AWS_ALLOW_HTTP`: Set to “true” to permit HTTP connections without TLS
 
-== Loading data with Python
+== Loading data into a table with Python
 
 Data can be loaded into a table using the `table.load()` function
 
 [source,python]
 ----
 from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
 
 fullPathToFile = "file://content/drive/place/thing/purchases.parquet"
-table.load("Purchases", fullPathToFile)
+table.load(table_name = "Purchases", file = fullPathToFile)
 ----
 
 [TIP]
@@ -133,12 +137,12 @@ The result of running `load()` is a `data_token_id``. The data token ID is a uni
 data_token_id: "aa2***a6b9"
 ----
 
-== Loading data with the CLI
+== Loading data into a table with the CLI
 
 Files can be loaded into a table using the CLI.
 When loading files with the CLI, the given path must be local to the Kaskada service.
 
-The file must be encoded as either CSV or Parquet version 2.
+The file must be encoded as either CSV or Parquet.
 
 [source,bash]
 ----

--- a/docs-src/modules/developing/pages/materializations.adoc
+++ b/docs-src/modules/developing/pages/materializations.adoc
@@ -70,14 +70,6 @@ materializations:
 
 == Managing Materializations with Python
 
-All methods on this page use from the `materialization` object. Be sure
-to import it before running any method:
-
-[source,python]
-----
-from kaskada import materialization
-----
-
 === Creating a Materialization
 
 To create a materialization, we'll start by describing the expression
@@ -87,6 +79,11 @@ logic and might require some iteration to get just right.
 
 [source,python]
 ----
+from kaskada import materialization
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 purchase_stats = """
 {
     time: Purchase.purchase_time,
@@ -118,6 +115,11 @@ Here is an example of listing tables:
 
 [source,python]
 ----
+from kaskada import materialization
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 materialization.list_materializations("Purchase")
 ----
 
@@ -127,6 +129,11 @@ You can get a materialization using its name:
 
 [source,python]
 ----
+from kaskada import materialization
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 materialization.get_materialization("PurchaseStats")
 ----
 
@@ -142,6 +149,11 @@ You can delete a materialization using its name:
 
 [source,python]
 ----
+from kaskada import materialization
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 materialization.delete_materialization("PurchaseStats")
 ----
 

--- a/docs-src/modules/developing/pages/queries.adoc
+++ b/docs-src/modules/developing/pages/queries.adoc
@@ -4,9 +4,10 @@ The following sections will help with writing queries.
 
 == Final vs Historical Results
 
-Every query can be computed in two different ways: final and historical.
-Historical queries return the full history of how an expression changes over time for every entity.
-Final queries return the result of the query expression for every entity after processing all events.
+Every query produces a timeline which may be returned in two different ways -- the final results (at a specific time) or all historic results.
+The "result behavior" configures which results are produced.
+Queries for historic results return the full history of how the values changed over time for each entity.
+Queries for final results return the latest result for each entity at the specified time (default is after all events have been processed).
 
 You determine which type of query to execute using the "result behavior" configuration at query time.
 By default, historical results are returned.
@@ -74,8 +75,10 @@ Using python directly is one way to write queries.
 
 [source,python]
 ----
-import pandas
 from kaskada import compute
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
 
 query = """{ 
   time: Purchase.purchase_time, 
@@ -84,8 +87,10 @@ query = """{
   min_amount: Purchase.amount | min()
 }"""
 
-response_parquet = compute.query(query=query).parquet.path
+response_parquet = compute.query(query = query).output_to.object_store.output_paths[0]
 
+# (Optional) view results as a Pandas dataframe.
+import pandas
 pandas.read_parquet(response_parquet)
 ----
 
@@ -215,8 +220,8 @@ t_purchases = kt.create_table(
     entity_key_column_name = "customer_id",
     subsort_column_name =    "subsort_id",
 )
-file_purchases1 = kt.upload_file(table="purchases", file_path="purchases_part1.parquet")
-file_purchases2 = kt.upload_file(table=t_purchases, file_path="purchases_part2.parquet")
+file_purchases1 = kt.load(table_name="purchases", file="purchases_part1.parquet")
+file_purchases2 = kt.load(table_name=t_purchases, file="purchases_part2.parquet")
 print(f"SUCCESS: Created Purchases table and uploaded data.")
 print("\t Table Response:")
 print(indent(t_purchases, 2, "\t"))
@@ -230,7 +235,7 @@ t_transactions = kt.create_table(
     entity_key_column_name = "id",
     subsort_column_name =    "idx",
 )
-file_transactions1 = kt.upload_file(table=t_transactions, file_path="transactions_part1.parquet")
+file_transactions1 = kt.load(table_name=t_transactions, file="transactions_part1.parquet")
 print(f"SUCCESS: Created Transactions table and uploaded data.")
 print("\t Table Response:")
 print(indent(t_transactions, 2, "\t"))

--- a/docs-src/modules/developing/pages/slices.adoc
+++ b/docs-src/modules/developing/pages/slices.adoc
@@ -63,18 +63,20 @@ The usage of a slice is only applicable at query time, and only _one_
 filter can be applied per query. To apply a filter to a query, use the
 Kaskada module method: `set_default_slice`.
 
-Here is an example of setting the slice filter:
-
-[source,python]
-----
-# entity_filter is created in the example above
-kda.set_default_slice(entity_filter)
-----
-
 After setting the slice, all subsequent queries will utilize the slice
 filter on the same session.
 
 === IPython (Jupyter) Extension
+
+[source,python]
+----
+from kaskada.slice_filters import EntityPercentFilter
+
+filter_percentage = 12.34
+entity_filter = EntityPercentFilter(filter_percentage)
+kda.set_default_slice(entity_filter)
+----
+
 
 [source,ipython]
 ----
@@ -92,6 +94,14 @@ filter on the same session.
 [source,python]
 ----
 from kaskada import compute
+from kaskada.api.session import LocalBuilder
+from kaskada.slice_filters import EntityPercentFilter
+
+session = LocalBuilder().build()
+
+filter_percentage = 12.34
+entity_filter = EntityPercentFilter(filter_percentage)
+kda.set_default_slice(entity_filter)
 
 query = '''
 {

--- a/docs-src/modules/developing/pages/tables.adoc
+++ b/docs-src/modules/developing/pages/tables.adoc
@@ -5,29 +5,26 @@ each row is a value of the same type.
 
 == Managing tables with Python
 
-All methods on this page use the `table` module. Be sure to import it
-before running any method:
-
-[source,python]
-----
-from kaskada import table
-----
-
 === Creating a Table
 
 When creating a table, you must provide information about how each row
 should be interpreted. You must describe:
 
-* A field containing the time associated with each row. The time should
-refer to when the event occurred.
-* An initial xref:fenl:entities[entity] key associated with each row. The
-entity should identify a _thing_ in the world related to each event.
+* The name of a column in your data that contains the time of each row
+(`time_column_name`). The time should refer to when the event occurred.
+* The name of a column in your data that contains the xref:fenl:entities.adoc[entity] key of each row
+(`entity_key_column_name`). The entity should identify a _thing_ in the
+world that each event is associated with. Don't worry too much about
+picking the "right" value here - it's easy to change the entity key in
+Fenl.
+
 
 Optionally:
 
-* A subsort column associated with each row. This value is used to order
-rows associated with the same time value. If no subsort column is
-provided, Kaskada will generate one.
+* An subsort column associated with each row (`subsort_column_name`).
+This value is used to order rows associated with the same time value.
+If no subsort column is provided, Kaskada will generate one.
+* A name describing the type of entity, for example "User" or "Purchase".
 
 For more information about these fields, see:
 xref:reference:expected-file-format[Expected File Format]
@@ -36,11 +33,18 @@ Here is an example of creating a table:
 
 [source,python]
 ----
+from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 table.create_table(
+  # The table's name
   table_name = "Purchase",
+  # The name of a column in your data that contains the time associated with each row
   time_column_name = "purchase_time",
+  # The name of a column in your data that contains the entity key associated with each row
   entity_key_column_name = "customer_id",
-  subsort_column_name = "subsort_id",
 )
 ----
 
@@ -65,7 +69,12 @@ Here is an example of listing tables:
 
 [source,python]
 ----
-table.list_tables(search = "chase")
+from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
+table.list_tables()
 ----
 
 === Get Table
@@ -74,7 +83,12 @@ You can get a table using its name:
 
 [source,python]
 ----
-table.get_table("Purchase")
+from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
+table.get_table(table = "Purchase")
 ----
 
 === Updating a Table
@@ -88,7 +102,12 @@ You can delete a table using its name:
 
 [source,python]
 ----
-table.delete_table("Purchase")
+from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
+table.delete_table(table = "Purchase")
 ----
 
 [WARNING]
@@ -105,13 +124,25 @@ functioning incorrectly.
 
 [source,python]
 ----
-table.delete_table("Purchase", force=True)
+from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
+table.delete_table(table = "Purchase", force = True)
 ----
 
 == Managing tables with the CLI
 
 The CLI manages Kaskada resources declaratively by managing spec files.
 A spec file is a YAML file describing a set of Kaskada resources, for examples tables and views.
+
+=== Creating, updating and deleting tables with the CLI
+
+The CLI uses a "declarative" API - rather than modifying resources directly you describe the desired state of Kaskada, and the `kaskada-cli sync` command makes whatever changes are needed to achieve this state.
+To create a table, add the table's description to your spec file and run `kaskada-cli sync apply`.
+To update a table, change the table's description in your spec file and run `kaskada-cli sync apply`.
+It is not currently possible to delete a table using the CLI.
 
 === The format of tables in a spec file.
 

--- a/docs-src/modules/developing/pages/views.adoc
+++ b/docs-src/modules/developing/pages/views.adoc
@@ -17,14 +17,6 @@ Views are useful any time you need to share or re-use expressions:
 
 == Managing views with Python
 
-All methods in this section are from the `view` object. Be sure to import
-it before running any method:
-
-[source,python]
-----
-from kaskada import view
-----
-
 === Creating a View
 
 To create a view, we'll start by describing the expression we'd like to
@@ -34,6 +26,11 @@ some iteration to get just right.
 
 [source,python]
 ----
+from kaskada import view
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 view.create_view(
     view_name = "PurchaseStats",
     expression = "{
@@ -79,6 +76,11 @@ without re-typing the expression:
 
 [source,python]
 ----
+from kaskada import view
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 view.create_view(
     view_name = "PurchaseStats",
     expression = purchase_stats.expression,
@@ -94,6 +96,11 @@ Here is an example of listing tables:
 
 [source,python]
 ----
+from kaskada import view
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 view.list_views("Purchase")
 ----
 
@@ -103,6 +110,11 @@ You can get a view using its name:
 
 [source,python]
 ----
+from kaskada import view
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 view.get_view("PurchaseStats")
 ----
 
@@ -117,6 +129,11 @@ You can delete a view using its name:
 
 [source,python]
 ----
+from kaskada import view
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 view.delete_view("PurchaseStats")
 ----
 
@@ -125,6 +142,14 @@ view.delete_view("PurchaseStats")
 
 The CLI manages Kaskada resources declaratively by managing spec files.
 A spec file is a YAML file describing a set of Kaskada resources, for examples tables and views.
+
+=== Creating, updating and deleting tables with the CLI
+
+
+The CLI uses a "declarative" API - rather than modifying resources directly you describe the desired state of Kaskada, and the `kaskada-cli sync` command makes whatever changes are needed to achieve this state.
+To create a table, add the table's description to your spec file and run `kaskada-cli sync apply`.
+To update a table, change the table's description in your spec file and run `kaskada-cli sync apply`.
+It is not currently possible to delete a table using the CLI.
 
 === The format of views in a spec file.
 

--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -50,10 +50,10 @@ You can start a local instance of the Kaskada service by running the manager and
 
 [TIP]
 .Allowing services to listen on OSX
-----
+====
 When using OSX, you may need to allow these services to create an API listener the first time you run these commands.
 This is normal, and indicates the services are working as expected - the API allows services to communicate between themselves.
-----
+====
 
 To verify they're installed correctly and executable, try running the following command (which lists any resources you've created):
 
@@ -141,7 +141,7 @@ names.
 
 You've now created your first table! 
 
-== Loading Data
+== Loading data into a table
 
 Now that we've created a table, we're ready to load some data into it.
 
@@ -153,8 +153,10 @@ section of the "Tables"] page.
 
 [source,shell]
 ----
+# Download a file to load and save it to path 'purchase.parquet'
 curl -L "https://drive.google.com/uc?export=download&id=1SLdIw9uc0RGHY-eKzS30UBhN0NJtslkk" -o purchase.parquet
 
+# Load the file into the Purchase table (which was created in the previous step)
 ./kaskada-cli load \
     --table Purchase \
     --file-path file://${PWD}/purchase.parquet
@@ -165,7 +167,7 @@ The file's content is added to the table.
 For more help with tables and loading data, see xref:developing:tables.adoc[Reference -
 Tables]
 
-== Querying Data
+== Querying data
 
 You can write queries in a number of ways with Kaskada. As you are
 iterating it can be helpful to build up your queries as components
@@ -189,12 +191,13 @@ When working with larger data sets, you may want to write the results to a file 
 ====
 
 Let's walk through this command.
-We begin by using the CLI to run a query: `kaskada-cli query run`.
+
+1. We begin by using the CLI to run a query: `kaskada-cli query run`.
 CLI commands are organized into groups like `query`, `load`, and `sync` - each group contains a set of related sub-commands.
-In order to see the results of our query, we used the command flag `--stdout`; the default behavior is to write results to a file and return a JSON object describing the result of the query.
-Finally, we specified how to encode the results with the flag `--response-as csv`.
-CSV is a good format for writing results to STDOUT, but the default is to encode results in Parquet, which is a much more efficient encoding for larger datasets.
-The query is enclosed between `<<EOS` and `EOS` - this is Bash syntax for "heredocs", which allow you to easily write multi-line strings and pass them into the CLI on STDIN.
+2. In order to see the results of our query, we used the command flag `--stdout`; the default behavior is to write results to a file and return a JSON object describing the result of the query.
+3. Finally, we specified how to encode the results with the flag `--response-as csv`.
+CSV is a good format for writing results to STDOUT because it's relatively human-readible. The default is to encode results in Parquet, which is a much more efficient encoding for larger datasets.
+4. The query is enclosed between `<<EOS` and `EOS` - this is Bash syntax for "heredocs", which allow you to easily write multi-line strings and pass them into the CLI on STDIN.
 
 
 It can be helpful to limit your results to a single entity.

--- a/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
@@ -51,6 +51,8 @@ pip install kaskada
 ====
 Depending on you Python installation and configuration you may have `pip3` instead of `pip` available in your terminal. 
 If you do have `pip3` replace `pip` with `pip3` in your command, i.e., `pip3 install kaskada`
+
+You can see what version of Python `pip` uses by running `pip -V`
 ====
 
 [IMPORTANT]
@@ -109,7 +111,7 @@ The special string `%%fenl` will also connect to the Kaskada components that we 
 
 Congratulations, you now have Kaskada locally installed and you can start loading and querying your data using Kaskada inside a Jupyter notebook. 
 
-== Loading Data 
+== Loading Data into a Table
 
 Kaskada stores data in _tables_. Tables consist of multiple rows, and
 each row is a value of the same type.
@@ -119,15 +121,13 @@ each row is a value of the same type.
 When creating a table, you must provide some information about how each
 row should be interpreted. You must describe:
 
-* A field containing the time associated with each row
+* The name of a column in your data that contains the time of each row
 (`time_column_name`). The time should refer to when the event occurred.
-* An initial xref:fenl:entities.adoc[entity] key associated with each row
+* The name of a column in your data that contains the xref:fenl:entities.adoc[entity] key of each row
 (`entity_key_column_name`). The entity should identify a _thing_ in the
 world that each event is associated with. Don't worry too much about
 picking the "right" value here - it's easy to change the entity key in
 Fenl.
-* An (optional) subsort column associated with each row (`subsort_column_name`).
-This value is used to order rows associated with the same time value.
 
 For more information about these fields, see:
 xref:ROOT:loading-data.adoc#file-format[Expected File Format]
@@ -135,12 +135,17 @@ xref:ROOT:loading-data.adoc#file-format[Expected File Format]
 [source,python]
 ----
 from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
 
 table.create_table(
+  # The table's name
   table_name = "Purchase",
+  # The name of a column in your data that contains the time associated with each row
   time_column_name = "purchase_time",
+  # The name of a column in your data that contains the entity key associated with each row
   entity_key_column_name = "customer_id",
-  subsort_column_name = "subsort_id",
 )
 ----
 
@@ -186,26 +191,27 @@ request_details {
 Now that we've created a table, we're ready to load some data into it.
 
 Data can be loaded into a table in multiple ways. In this example we'll
-load the contents of a Pandas dataframe into the table. To learn about
+load the contents of a Parquet file into the table. To learn about
 the different ways data can be loaded into a table, see the
 xref:ROOT:loading-data.adoc["Loading Data"]
 section of the docs.
 
 [source,python]
 ----
-import pandas
+from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
 
 # A sample Parquet file provided by Kaskada for testing
-purchases_url = "https://drive.google.com/uc?export=download&id=1SLdIw9uc0RGHY-eKzS30UBhN0NJtslkk"
+# Available at https://drive.google.com/uc?export=download&id=1SLdIw9uc0RGHY-eKzS30UBhN0NJtslkk
+purchases_path = "file:///absolute/path/to/purchases.parquet"
 
-# Read the file into a Pandas Dataframe
-purchases = pandas.read_parquet(purchases_url)
-
-# Upload the dataframe's contents to the Purchase table
-table.load_dataframe("Purchase", purchases)
+# Upload the files's contents to the Purchase table (which was created in the previous step)
+table.load(table_name = "Purchase", file = purchases_path)
 ----
 
-The result of running `load_dataframe` is a `data_token_id`. The
+The result of running `load` is a `data_token_id`. The
 data token ID is a unique reference to the data currently stored in the
 system.
 
@@ -227,6 +233,11 @@ loaded into each:
 
 [source,python]
 ----
+from kaskada import table
+from kaskada.api.session import LocalBuilder
+
+session = LocalBuilder().build()
+
 table.list_tables()
 ----
 
@@ -300,6 +311,7 @@ This makes it easier to see how a single entity changes over time.
 %%fenl
 Purchase | when(Purchase.customer_id == "patrick")
 ----
+
 In this example, we build a pipeline of functions using the `|` character.
 Pipelines are an easy way to use the results of one expression as the input to another expresion.
 In this example we begin with the timeline produced by the table `Purchase`, then filter it to the set of times where the purchase's customer is `"patrick"`. 


### PR DESCRIPTION
* Explain how to know if you need pip or pip3 in the “tip”
* Remove redundant title in table loading warning.
* Change titles involved with loading to make it clear that you’re loading into a table
* Output the log location when starting a subprocess in Python
* Fix method names “load_file -> load”
* Improve “client must be provided” error to suggest creating a session
* Add comments to arguments in all examples clarifying the argument’s meaning
* Reduce use of Pandas where possible
* Remove use of “search” parameter in table list call (or move to a subsection related to searching)