### PR TITLE
(ci) workaround to allow python client workflow to be required

### DIFF
--- a/.github/workflows/ci_client_python.yml
+++ b/.github/workflows/ci_client_python.yml
@@ -61,47 +61,60 @@ jobs:
           # Python gRPC code is generated in src/kaskada/kaskada
           path: clients/python/src/kaskada/kaskada
 
+  # if: statement is on each *step* instead of the whole job due to 
+  # https://github.com/actions/runner/issues/952
+  # and https://github.com/orgs/community/discussions/9141
   python_client_build:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8"]
-
     needs: [python_client_skip, python_protos]
-    if: needs.python_client_skip.outputs.should_skip != 'true'
+    
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: ./clients/python
     steps:
       - uses: actions/checkout@v3
+        if: needs.python_client_skip.outputs.should_skip != 'true'
       - uses: actions/setup-python@v4
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download Python Proto Artifact
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         uses: actions/download-artifact@v3
         with:
           name: python-protos
           path: clients/python/src/kaskada/kaskada
       - name: Run image
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         uses: abatilo/actions-poetry@v2.0.0
         with:
           poetry-version: 1.3.2
       - name: Install project
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         run: poetry install
       - name: Python Client Style
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         run: poetry run poe style
       - name: Python Client Types
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         run: poetry run poe types
       - name: Python Client Lint
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         run: poetry run poe lint
       - name: Python Client Test
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         run: poetry run poe test
       - name: Python Client Docs
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         run: poetry run poe docs
 
       - name: Upload Python Client Artifacts
+        if: needs.python_client_skip.outputs.should_skip != 'true'
         uses: actions/upload-artifact@v3
         with:
           name: kaskada-client-docs


### PR DESCRIPTION

In order to make the job that builds the python code *required* for our PRs we need to move the `if` expression in the yaml file to *each step* as opposed to *the whole job*. 

When the `if` statement is on the whole job and we require this job for PRs the PRs workflow hangs 

See 
  * https://github.com/actions/runner/issues/952
  * https://github.com/orgs/community/discussions/9141


So the dirty workaround for now is to copy the `if` statement to each step. This is noisy but also wasteful since we still create the matrix entries and skip each step using up resources. :man_facepalming: 

