### PR TITLE
added resource delete to the cli

### DIFF
--- a/clients/cli/api/api_test.go
+++ b/clients/cli/api/api_test.go
@@ -210,7 +210,7 @@ func Test_apiClient_Delete(t *testing.T) {
 				table:           tt.fields.table,
 				view:            tt.fields.view,
 			}
-			if err := c.Delete(tt.args.item); (err != nil) != tt.wantErr {
+			if err := c.Delete(tt.args.item, true); (err != nil) != tt.wantErr {
 				t.Errorf("apiClient.Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -380,7 +380,7 @@ func (*mockMaterializationClient) Create(item *apiv1alpha.Materialization) error
 }
 
 // Delete implements MaterializationClient
-func (*mockMaterializationClient) Delete(name string) error {
+func (*mockMaterializationClient) Delete(name string, force bool) error {
 	return nil
 }
 
@@ -410,7 +410,7 @@ func (*mockTableClient) Create(item *apiv1alpha.Table) error {
 }
 
 // Delete implements TableClient
-func (*mockTableClient) Delete(name string) error {
+func (*mockTableClient) Delete(name string, force bool) error {
 	return nil
 }
 
@@ -436,7 +436,7 @@ func (*mockViewClient) Create(item *apiv1alpha.View) error {
 }
 
 // Delete implements ViewClient
-func (*mockViewClient) Delete(name string) error {
+func (*mockViewClient) Delete(name string, force bool) error {
 	return nil
 }
 

--- a/clients/cli/api/materialization_client.go
+++ b/clients/cli/api/materialization_client.go
@@ -19,7 +19,7 @@ type MaterializationClient interface {
 	List() ([]*apiv1alpha.Materialization, error)
 	Get(name string) (*apiv1alpha.Materialization, error)
 	Create(item *apiv1alpha.Materialization) error
-	Delete(name string) error
+	Delete(name string, force bool) error
 }
 
 func NewMaterializationServiceClient(ctx context.Context, conn *grpc.ClientConn) MaterializationClient {
@@ -63,7 +63,7 @@ func (c materializationClient) Create(item *apiv1alpha.Materialization) error {
 	return nil
 }
 
-func (c materializationClient) Delete(name string) error {
+func (c materializationClient) Delete(name string, force bool) error {
 	_, err := c.client.DeleteMaterialization(c.ctx, &apiv1alpha.DeleteMaterializationRequest{MaterializationName: name})
 	if err != nil {
 		log.Debug().Err(err).Str("name", name).Msg("issue deleting materialization")

--- a/clients/cli/api/table_client.go
+++ b/clients/cli/api/table_client.go
@@ -19,7 +19,7 @@ type TableClient interface {
 	List() ([]*apiv1alpha.Table, error)
 	Get(name string) (*apiv1alpha.Table, error)
 	Create(item *apiv1alpha.Table) error
-	Delete(name string) error
+	Delete(name string, force bool) error
 	LoadFile(name string, fileInput *apiv1alpha.FileInput) error
 }
 
@@ -58,8 +58,8 @@ func (c tableClient) Create(item *apiv1alpha.Table) error {
 	return nil
 }
 
-func (c tableClient) Delete(name string) error {
-	_, err := c.client.DeleteTable(c.ctx, &apiv1alpha.DeleteTableRequest{TableName: name, Force: true})
+func (c tableClient) Delete(name string, force bool) error {
+	_, err := c.client.DeleteTable(c.ctx, &apiv1alpha.DeleteTableRequest{TableName: name, Force: force})
 	if err != nil {
 		log.Debug().Err(err).Str("name", name).Msg("issue deleting table")
 		return err

--- a/clients/cli/api/view_client.go
+++ b/clients/cli/api/view_client.go
@@ -19,7 +19,7 @@ type ViewClient interface {
 	List() ([]*apiv1alpha.View, error)
 	Get(name string) (*apiv1alpha.View, error)
 	Create(item *apiv1alpha.View) error
-	Delete(name string) error
+	Delete(name string, force bool) error
 }
 
 func NewViewServiceClient(ctx context.Context, conn *grpc.ClientConn) ViewClient {
@@ -63,8 +63,8 @@ func (c viewClient) Create(item *apiv1alpha.View) error {
 	return nil
 }
 
-func (c viewClient) Delete(name string) error {
-	_, err := c.client.DeleteView(c.ctx, &apiv1alpha.DeleteViewRequest{ViewName: name, Force: true})
+func (c viewClient) Delete(name string, force bool) error {
+	_, err := c.client.DeleteView(c.ctx, &apiv1alpha.DeleteViewRequest{ViewName: name, Force: force})
 	if err != nil {
 		log.Debug().Err(err).Str("name", name).Msg("issue deleting view")
 		return err

--- a/clients/cli/cmd/materialization/delete.go
+++ b/clients/cli/cmd/materialization/delete.go
@@ -1,0 +1,24 @@
+package materialization
+
+import (
+	"github.com/kaskada-ai/kaskada/clients/cli/api"
+	"github.com/kaskada-ai/kaskada/clients/cli/utils"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	apiv1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
+)
+
+// deleteCmd represents the materialization delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Deletes a materialization.",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.LogAndQuitIfErrorExists(api.NewApiClient().Delete(&apiv1alpha.Materialization{MaterializationName: materialization}, true))
+		log.Info().Msg("Success!")
+	},
+}
+
+func init() {
+	initMaterializationFlag(deleteCmd, "The materialization to delete.")
+}

--- a/clients/cli/cmd/materialization/materialization.go
+++ b/clients/cli/cmd/materialization/materialization.go
@@ -1,0 +1,29 @@
+package materialization
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// MaterializationCmd represents the materialization command
+var MaterializationCmd = &cobra.Command{
+	Use:   "materialization",
+	Short: "A set of commands for interacting with kaskada materializations",
+	/*
+		Long: `A longer description that spans multiple lines and likely contains examples
+		and usage of using your command. For example:
+
+		Cobra is a CLI library for Go that empowers applications.
+		This application is a tool to generate the needed files
+		to quickly create a Cobra application.`,
+	*/
+}
+
+func init() {
+	MaterializationCmd.AddCommand(deleteCmd)
+}
+
+var materialization string
+func initMaterializationFlag(cmd *cobra.Command, description string) {
+	cmd.Flags().StringVarP(&materialization, "materialization", "m", "", description)
+	cmd.MarkFlagRequired("materialization")
+}

--- a/clients/cli/cmd/query/query.go
+++ b/clients/cli/cmd/query/query.go
@@ -1,13 +1,13 @@
-package cmd
+package query
 
 import (
 	"github.com/spf13/cobra"
 )
 
-// syncCmd represents the sync command
-var syncCmd = &cobra.Command{
-	Use:   "sync",
-	Short: "A set of commands for interacting with kaskada resources as code",
+// QueryCmd represents the query command
+var QueryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "A set of commands for running queries on kaskada",
 	/*
 		Long: `A longer description that spans multiple lines and likely contains examples
 		and usage of using your command. For example:
@@ -19,5 +19,5 @@ var syncCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(syncCmd)
+	QueryCmd.AddCommand(runCmd)
 }

--- a/clients/cli/cmd/query/run.go
+++ b/clients/cli/cmd/query/run.go
@@ -1,4 +1,4 @@
-package cmd
+package query
 
 import (
 	"bytes"
@@ -17,34 +17,33 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/kaskada-ai/kaskada/clients/cli/api"
+	"github.com/kaskada-ai/kaskada/clients/cli/utils"
 	apiv1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 	// preparev1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/prepare/v1alpha"
 )
 
 func init() {
-	queryCmd.AddCommand(queryRunCmd)
+	runCmd.Flags().String("response-as", "parquet", "(Optional) How to encode the results.  Either 'parquet' or 'csv'.")
+	runCmd.Flags().String("data-token", "", "(Optional) A token to run queries against. Enables repeatable queries.")
+	runCmd.Flags().String("result-behavior", "all-results", "(Optional) Determines how results are returned.  Either 'all-results' or 'final-results'.")
+	runCmd.Flags().Int64("preview-rows", 0, "(Optional) Produces a preview of the results with at least this many rows.")
+	runCmd.Flags().Bool("dry-run", false, "(Optional) If this is `true`, then the query is validated and if there are no errors, the resultant schema is returned. No actual computation of results is performed.")
+	runCmd.Flags().Bool("experimental-features", false, "(Optional) If this is `true`, then experimental features are allowed.  Data returned when using this flag is not guaranteed to be correct.")
+	runCmd.Flags().Int64("changed-since-time", 0, "(Optional) Unix timestamp bound (inclusive) after which results will be output. If 'response-behavior' is 'all-results', this will include rows for changes (events and ticks) after this time (inclusive). If it is 'final-results', this will include a final result for any entity that would be included in the changed results.")
+	runCmd.Flags().Bool("stdout", false, "(Optional) If this is `true`, output results are sent to STDOUT")
 
-	queryRunCmd.Flags().String("response-as", "parquet", "(Optional) How to encode the results.  Either 'parquet' or 'csv'.")
-	queryRunCmd.Flags().String("data-token", "", "(Optional) A token to run queries against. Enables repeatable queries.")
-	queryRunCmd.Flags().String("result-behavior", "all-results", "(Optional) Determines how results are returned.  Either 'all-results' or 'final-results'.")
-	queryRunCmd.Flags().Int64("preview-rows", 0, "(Optional) Produces a preview of the results with at least this many rows.")
-	queryRunCmd.Flags().Bool("dry-run", false, "(Optional) If this is `true`, then the query is validated and if there are no errors, the resultant schema is returned. No actual computation of results is performed.")
-	queryRunCmd.Flags().Bool("experimental-features", false, "(Optional) If this is `true`, then experimental features are allowed.  Data returned when using this flag is not guaranteed to be correct.")
-	queryRunCmd.Flags().Int64("changed-since-time", 0, "(Optional) Unix timestamp bound (inclusive) after which results will be output. If 'response-behavior' is 'all-results', this will include rows for changes (events and ticks) after this time (inclusive). If it is 'final-results', this will include a final result for any entity that would be included in the changed results.")
-	queryRunCmd.Flags().Bool("stdout", false, "(Optional) If this is `true`, output results are sent to STDOUT")
-
-	viper.BindPFlag("response_as", queryRunCmd.Flags().Lookup("response-as"))
-	viper.BindPFlag("data_token", queryRunCmd.Flags().Lookup("data-token"))
-	viper.BindPFlag("result_behavior", queryRunCmd.Flags().Lookup("result-behavior"))
-	viper.BindPFlag("preview_rows", queryRunCmd.Flags().Lookup("preview-rows"))
-	viper.BindPFlag("dry_run", queryRunCmd.Flags().Lookup("dry-run"))
-	viper.BindPFlag("experimental_features", queryRunCmd.Flags().Lookup("experimental-features"))
-	viper.BindPFlag("changed_since_time", queryRunCmd.Flags().Lookup("changed-since-time"))
-	viper.BindPFlag("stdout", queryRunCmd.Flags().Lookup("stdout"))
+	viper.BindPFlag("response_as", runCmd.Flags().Lookup("response-as"))
+	viper.BindPFlag("data_token", runCmd.Flags().Lookup("data-token"))
+	viper.BindPFlag("result_behavior", runCmd.Flags().Lookup("result-behavior"))
+	viper.BindPFlag("preview_rows", runCmd.Flags().Lookup("preview-rows"))
+	viper.BindPFlag("dry_run", runCmd.Flags().Lookup("dry-run"))
+	viper.BindPFlag("experimental_features", runCmd.Flags().Lookup("experimental-features"))
+	viper.BindPFlag("changed_since_time", runCmd.Flags().Lookup("changed-since-time"))
+	viper.BindPFlag("stdout", runCmd.Flags().Lookup("stdout"))
 }
 
-// queryRunCmd represents the queryRun command
-var queryRunCmd = &cobra.Command{
+// runCmd represents the query run command
+var runCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Use:   "run \"query-text\"",
 	Short: "executes a query on kaskada",
@@ -76,21 +75,21 @@ var queryRunCmd = &cobra.Command{
 				},
 			}
 		default:
-			logAndQuitIfErrorExists(fmt.Errorf("'response-as' must be 'csv' or 'parquet'"))
+			utils.LogAndQuitIfErrorExists(fmt.Errorf("'response-as' must be 'csv' or 'parquet'"))
 		}
 
 		var expression string
 		if len(args) == 0 {
 			stdin, err := io.ReadAll(os.Stdin)
-			logAndQuitIfErrorExists(err)
+			utils.LogAndQuitIfErrorExists(err)
 			expression = string(stdin)
 		} else {
 			expression = args[0]
 		}
 		queryReq := &apiv1alpha.CreateQueryRequest{
 			Query: &apiv1alpha.Query{
-				Expression: expression,
-				Destination:   destination,
+				Expression:  expression,
+				Destination: destination,
 			},
 			QueryOptions: &apiv1alpha.QueryOptions{
 				DryRun:               viper.GetBool("dry_run"),
@@ -111,7 +110,7 @@ var queryRunCmd = &cobra.Command{
 		case "final-results":
 			queryReq.Query.ResultBehavior = apiv1alpha.Query_RESULT_BEHAVIOR_FINAL_RESULTS
 		default:
-			logAndQuitIfErrorExists(fmt.Errorf("'result-behavior' must be 'all-results' or 'final-results'"))
+			utils.LogAndQuitIfErrorExists(fmt.Errorf("'result-behavior' must be 'all-results' or 'final-results'"))
 		}
 
 		previewRows := viper.GetInt64("preview_rows")
@@ -128,7 +127,7 @@ var queryRunCmd = &cobra.Command{
 
 		resp, err := api.NewApiClient().Query(queryReq)
 
-		logAndQuitIfErrorExists(err)
+		utils.LogAndQuitIfErrorExists(err)
 
 		if viper.GetBool("stdout") && resp.Destination != nil {
 
@@ -136,16 +135,16 @@ var queryRunCmd = &cobra.Command{
 			case *apiv1alpha.Destination_ObjectStore:
 				for _, path := range outputTo.ObjectStore.OutputPaths.Paths {
 					f, err := os.Open(strings.TrimPrefix(path, `file://`))
-					logAndQuitIfErrorExists(err)
+					utils.LogAndQuitIfErrorExists(err)
 
 					_, err = io.Copy(os.Stdout, f)
-					logAndQuitIfErrorExists(err)
+					utils.LogAndQuitIfErrorExists(err)
 				}
 			}
 		} else {
 			jsonBytes, err := protojson.Marshal(resp)
 
-			logAndQuitIfErrorExists(err)
+			utils.LogAndQuitIfErrorExists(err)
 
 			var out bytes.Buffer
 			json.Indent(&out, jsonBytes, "", "\t")

--- a/clients/cli/cmd/root.go
+++ b/clients/cli/cmd/root.go
@@ -4,6 +4,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kaskada-ai/kaskada/clients/cli/cmd/materialization"
+	"github.com/kaskada-ai/kaskada/clients/cli/cmd/query"
+	"github.com/kaskada-ai/kaskada/clients/cli/cmd/sync"
+	"github.com/kaskada-ai/kaskada/clients/cli/cmd/table"
+	"github.com/kaskada-ai/kaskada/clients/cli/cmd/view"
+	"github.com/kaskada-ai/kaskada/clients/cli/utils"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -31,6 +37,13 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	rootCmd.AddCommand(table.TableCmd)
+	rootCmd.AddCommand(view.ViewCmd)
+	rootCmd.AddCommand(materialization.MaterializationCmd)
+	rootCmd.AddCommand(query.QueryCmd)
+	rootCmd.AddCommand(sync.SyncCmd)
+	rootCmd.AddCommand(LoadCmd)
+
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
@@ -38,7 +51,7 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initLogging, initConfig)
+	cobra.OnInitialize(utils.InitLogging, initConfig)
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
@@ -61,10 +74,6 @@ func init() {
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
-}
-
-func initLogging() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -94,11 +103,5 @@ func initConfig() {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	} else {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	}
-}
-
-func logAndQuitIfErrorExists(err error) {
-	if err != nil {
-		log.Fatal().Err(err).Send()
 	}
 }

--- a/clients/cli/cmd/sync/apply.go
+++ b/clients/cli/cmd/sync/apply.go
@@ -1,4 +1,4 @@
-package cmd
+package sync
 
 import (
 	"fmt"
@@ -29,20 +29,18 @@ var applyCmd = &cobra.Command{
 		files := viper.GetStringSlice("apply_file")
 		log.Debug().Interface("files", files).Send()
 		if len(files) == 0 {
-			logAndQuitIfErrorExists(fmt.Errorf("at least one `file` flag must be set"))
+			utils.LogAndQuitIfErrorExists(fmt.Errorf("at least one `file` flag must be set"))
 		}
 
 		apiClient := api.NewApiClient()
 		planResult, err := utils.Plan(apiClient, files)
-		logAndQuitIfErrorExists(err)
-		logAndQuitIfErrorExists(utils.Apply(apiClient, *planResult))
+		utils.LogAndQuitIfErrorExists(err)
+		utils.LogAndQuitIfErrorExists(utils.Apply(apiClient, *planResult))
 		log.Info().Msg("Success!")
 	},
 }
 
 func init() {
-	syncCmd.AddCommand(applyCmd)
-
 	applyCmd.Flags().StringArrayP("file", "f", []string{}, "specify one or more file-paths of yaml spec files")
 	viper.BindPFlag("apply_file", applyCmd.Flags().Lookup("file"))
 }

--- a/clients/cli/cmd/sync/export.go
+++ b/clients/cli/cmd/sync/export.go
@@ -1,4 +1,4 @@
-package cmd
+package sync
 
 import (
 	"fmt"
@@ -39,30 +39,30 @@ var exportCmd = &cobra.Command{
 		viewNames := viper.GetStringSlice("view")
 
 		if !getAll && len(materializationNames)+len(tableNames)+len(viewNames) == 0 {
-			logAndQuitIfErrorExists(fmt.Errorf("either `all`, `materialization`, `table`, or `view` flag needs to be set at least once"))
+			utils.LogAndQuitIfErrorExists(fmt.Errorf("either `all`, `materialization`, `table`, or `view` flag needs to be set at least once"))
 		}
 
 		if getAll {
 			materializations, err = exportMaterializations(apiClient)
-			logAndQuitIfErrorExists(err)
+			utils.LogAndQuitIfErrorExists(err)
 			tables, err = exportTables(apiClient)
-			logAndQuitIfErrorExists(err)
+			utils.LogAndQuitIfErrorExists(err)
 			views, err = exportViews(apiClient)
-			logAndQuitIfErrorExists(err)
+			utils.LogAndQuitIfErrorExists(err)
 		} else {
 			for _, materializationName := range materializationNames {
 				materialization, err := exportMaterialization(apiClient, materializationName)
-				logAndQuitIfErrorExists(err)
+				utils.LogAndQuitIfErrorExists(err)
 				materializations = append(materializations, materialization)
 			}
 			for _, tableName := range tableNames {
 				table, err := exportTable(apiClient, tableName)
-				logAndQuitIfErrorExists(err)
+				utils.LogAndQuitIfErrorExists(err)
 				tables = append(tables, table)
 			}
 			for _, viewName := range viewNames {
 				view, err := exportView(apiClient, viewName)
-				logAndQuitIfErrorExists(err)
+				utils.LogAndQuitIfErrorExists(err)
 				views = append(views, view)
 			}
 		}
@@ -74,13 +74,13 @@ var exportCmd = &cobra.Command{
 		}
 
 		yamlData, err := utils.ProtoToYaml(spec)
-		logAndQuitIfErrorExists(err)
+		utils.LogAndQuitIfErrorExists(err)
 
 		filePath := viper.GetString("file-path")
 		if filePath == "" {
 			fmt.Printf("%s\n", yamlData)
 		} else {
-			logAndQuitIfErrorExists(os.WriteFile(filePath, yamlData, 0666))
+			utils.LogAndQuitIfErrorExists(os.WriteFile(filePath, yamlData, 0666))
 		}
 		log.Info().Msg("Success!")
 	},
@@ -165,8 +165,6 @@ func exportView(apiClient api.ApiClient, viewName string) (*apiv1alpha.View, err
 }
 
 func init() {
-	syncCmd.AddCommand(exportCmd)
-
 	exportCmd.Flags().Bool("all", false, "set this flag to export all tables, views, and materializations in the system")
 	exportCmd.Flags().StringP("file-path", "f", "", "specify a file path to export the resources to, instead of exporting to std-out")
 	exportCmd.Flags().StringArrayP("materialization", "m", []string{}, "the name of the `materialization` resource to export.  This flag can be set multiple times to specify multiple materialization.")

--- a/clients/cli/cmd/sync/export_test.go
+++ b/clients/cli/cmd/sync/export_test.go
@@ -1,4 +1,4 @@
-package cmd
+package sync
 
 import (
 	"reflect"
@@ -243,7 +243,7 @@ func (*mockApiClient) Create(item protoreflect.ProtoMessage) error {
 }
 
 // Delete implements api.ApiClient
-func (*mockApiClient) Delete(item protoreflect.ProtoMessage) error {
+func (*mockApiClient) Delete(item protoreflect.ProtoMessage, force bool) error {
 	panic("unimplemented")
 }
 

--- a/clients/cli/cmd/sync/plan.go
+++ b/clients/cli/cmd/sync/plan.go
@@ -1,4 +1,4 @@
-package cmd
+package sync
 
 import (
 	"fmt"
@@ -21,19 +21,17 @@ var planCmd = &cobra.Command{
 		files := viper.GetStringSlice("plan_file")
 
 		if len(files) == 0 {
-			logAndQuitIfErrorExists(fmt.Errorf("at least one `file` flag must be set"))
+			utils.LogAndQuitIfErrorExists(fmt.Errorf("at least one `file` flag must be set"))
 		}
 
 		apiClient := api.NewApiClient()
 		_, err := utils.Plan(apiClient, files)
-		logAndQuitIfErrorExists(err)
+		utils.LogAndQuitIfErrorExists(err)
 		log.Info().Msg("Success!")
 	},
 }
 
 func init() {
-	syncCmd.AddCommand(planCmd)
-
 	planCmd.Flags().StringArrayP("file", "f", []string{}, "specify one or more file-paths of yaml spec files")
 	viper.BindPFlag("plan_file", planCmd.Flags().Lookup("file"))
 }

--- a/clients/cli/cmd/sync/sync.go
+++ b/clients/cli/cmd/sync/sync.go
@@ -1,13 +1,13 @@
-package cmd
+package sync
 
 import (
 	"github.com/spf13/cobra"
 )
 
-// queryCmd represents the query command
-var queryCmd = &cobra.Command{
-	Use:   "query",
-	Short: "A set of commands for running queries on kaskada",
+// SyncCmd represents the sync command
+var SyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "A set of commands for interacting with kaskada resources as code",
 	/*
 		Long: `A longer description that spans multiple lines and likely contains examples
 		and usage of using your command. For example:
@@ -19,5 +19,8 @@ var queryCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(queryCmd)
+	SyncCmd.AddCommand(exportCmd)
+	SyncCmd.AddCommand(planCmd)
+	SyncCmd.AddCommand(applyCmd)
 }
+

--- a/clients/cli/cmd/table/delete.go
+++ b/clients/cli/cmd/table/delete.go
@@ -1,0 +1,27 @@
+package table
+
+import (
+	"github.com/kaskada-ai/kaskada/clients/cli/api"
+	"github.com/kaskada-ai/kaskada/clients/cli/utils"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	apiv1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
+)
+
+// deleteCmd represents the table delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Deletes a table.",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.LogAndQuitIfErrorExists(api.NewApiClient().Delete(&apiv1alpha.Table{TableName: table}, force))
+		log.Info().Msg("Success!")
+	},
+}
+
+var force bool
+func init() {
+	initTableFlag(deleteCmd, "The table to delete.")
+
+	deleteCmd.Flags().BoolVar(&force, "force", false, "Force delete the table. This could break existing views and materializations.")
+}

--- a/clients/cli/cmd/table/load.go
+++ b/clients/cli/cmd/table/load.go
@@ -1,4 +1,4 @@
-package cmd
+package table
 
 import (
 	"fmt"
@@ -7,20 +7,19 @@ import (
 	"github.com/kaskada-ai/kaskada/clients/cli/utils"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	apiv1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 )
 
-// LoadCmd represents the load command
-var LoadCmd = &cobra.Command{
+// loadCmd represents the load command
+var loadCmd = &cobra.Command{
 	Use:   "load",
-	Short: "(deprecated) Use `table load` instead. Loads data into a table.",
+	Short: "Loads data into a table.",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info().Msg("starting load")
 
 		var fileType apiv1alpha.FileType
-		switch viper.GetString("file-type") {
+		switch loadFileType {
 		case "parquet", "":
 			fileType = apiv1alpha.FileType_FILE_TYPE_PARQUET
 		case "csv":
@@ -28,8 +27,6 @@ var LoadCmd = &cobra.Command{
 		default:
 			utils.LogAndQuitIfErrorExists(fmt.Errorf("unrecognized file type - must be one of 'parquet', 'csv'"))
 		}
-		table := viper.GetString("table")
-		files := viper.GetStringSlice("file-path")
 
 		if len(files) == 0 {
 			utils.LogAndQuitIfErrorExists(fmt.Errorf("at least one `file` flag must be set"))
@@ -44,8 +41,9 @@ var LoadCmd = &cobra.Command{
 	},
 }
 
+var loadFileType string
+var files []string
 func init() {
-	LoadCmd.Flags().String("file-type", "parquet", "(Optional) The type of file to load.  Either 'parquet' or 'csv'.")
-	LoadCmd.Flags().String("table", "", "The table to load data into.")
-	LoadCmd.Flags().String("file-path", "", "The path of the file to load on the Kaskada instance.")
+	loadCmd.Flags().StringVarP(&loadFileType, "file-type", "k", "parquet", "(Optional) The type of file to load.  Either 'parquet' or 'csv'.")
+	loadCmd.Flags().StringArrayVarP(&files, "file-path", "f", []string{}, "The path of the file to load on the Kaskada instance.")
 }

--- a/clients/cli/cmd/table/table.go
+++ b/clients/cli/cmd/table/table.go
@@ -1,0 +1,30 @@
+package table
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// TableCmd represents the table command
+var TableCmd = &cobra.Command{
+	Use:   "table",
+	Short: "A set of commands for interacting with kaskada tables",
+	/*
+		Long: `A longer description that spans multiple lines and likely contains examples
+		and usage of using your command. For example:
+
+		Cobra is a CLI library for Go that empowers applications.
+		This application is a tool to generate the needed files
+		to quickly create a Cobra application.`,
+	*/
+}
+
+func init() {
+	TableCmd.AddCommand(loadCmd)
+	TableCmd.AddCommand(deleteCmd)
+}
+
+var table string
+func initTableFlag(cmd *cobra.Command, description string) {
+	cmd.Flags().StringVarP(&table, "table", "t", "", description)
+	cmd.MarkFlagRequired("table")
+}

--- a/clients/cli/cmd/view/delete.go
+++ b/clients/cli/cmd/view/delete.go
@@ -1,0 +1,27 @@
+package view
+
+import (
+	"github.com/kaskada-ai/kaskada/clients/cli/api"
+	"github.com/kaskada-ai/kaskada/clients/cli/utils"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	apiv1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
+)
+
+// deleteCmd represents the view delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Deletes a view.",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.LogAndQuitIfErrorExists(api.NewApiClient().Delete(&apiv1alpha.View{ViewName: view}, force))
+		log.Info().Msg("Success!")
+	},
+}
+
+var force bool
+func init() {
+	initViewFlag(deleteCmd, "The view to delete.")
+
+	deleteCmd.Flags().BoolVar(&force, "force", false, "Force delete the view. This could break existing materializations.")
+}

--- a/clients/cli/cmd/view/view.go
+++ b/clients/cli/cmd/view/view.go
@@ -1,0 +1,29 @@
+package view
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ViewCmd represents the view command
+var ViewCmd = &cobra.Command{
+	Use:   "view",
+	Short: "A set of commands for interacting with kaskada views",
+	/*
+		Long: `A longer description that spans multiple lines and likely contains examples
+		and usage of using your command. For example:
+
+		Cobra is a CLI library for Go that empowers applications.
+		This application is a tool to generate the needed files
+		to quickly create a Cobra application.`,
+	*/
+}
+
+func init() {
+	ViewCmd.AddCommand(deleteCmd)
+}
+
+var view string
+func initViewFlag(cmd *cobra.Command, description string) {
+	cmd.Flags().StringVarP(&view, "view", "v", "", description)
+	cmd.MarkFlagRequired("view")
+}

--- a/clients/cli/utils/logger.go
+++ b/clients/cli/utils/logger.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func InitLogging() {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+}
+
+func LogAndQuitIfErrorExists(err error) {
+	if err != nil {
+		log.Fatal().Err(err).Send()
+	}
+}

--- a/clients/cli/utils/sync.go
+++ b/clients/cli/utils/sync.go
@@ -93,7 +93,7 @@ func Apply(apiClient api.ApiClient, plan planResult) error {
 	}
 	for _, resource := range plan.resourcesToReplace {
 		subLogger := log.With().Str("kind", reflect.TypeOf(resource).String()).Str("name", api.GetName(resource)).Logger()
-		if err := apiClient.Delete(resource); err != nil {
+		if err := apiClient.Delete(resource, true); err != nil {
 			subLogger.Error().Err(err).Msg("issue deleting resource before re-create")
 			return err
 		}

--- a/clients/cli/utils/sync_test.go
+++ b/clients/cli/utils/sync_test.go
@@ -80,7 +80,7 @@ func (*errorGetApiClient) Create(item protoreflect.ProtoMessage) error {
 }
 
 // Delete implements api.ApiClient
-func (*errorGetApiClient) Delete(item protoreflect.ProtoMessage) error {
+func (*errorGetApiClient) Delete(item protoreflect.ProtoMessage, force bool) error {
 	panic("unimplemented")
 }
 
@@ -112,7 +112,7 @@ func (*notFoundGetApiClient) Create(item protoreflect.ProtoMessage) error {
 }
 
 // Delete implements api.ApiClient
-func (*notFoundGetApiClient) Delete(item protoreflect.ProtoMessage) error {
+func (*notFoundGetApiClient) Delete(item protoreflect.ProtoMessage, force bool) error {
 	panic("unimplemented")
 }
 
@@ -143,7 +143,7 @@ func (*getApiClient) Create(item protoreflect.ProtoMessage) error {
 }
 
 // Delete implements api.ApiClient
-func (*getApiClient) Delete(item protoreflect.ProtoMessage) error {
+func (*getApiClient) Delete(item protoreflect.ProtoMessage, force bool) error {
 	panic("unimplemented")
 }
 

--- a/docs-src/modules/developing/pages/materializations.adoc
+++ b/docs-src/modules/developing/pages/materializations.adoc
@@ -78,6 +78,7 @@ purchase statistics for each user. This definition depends on business
 logic and might require some iteration to get just right.
 
 [source,python]
+.with Python:
 ----
 from kaskada import materialization
 from kaskada.api.session import LocalBuilder
@@ -114,6 +115,7 @@ for your user. An optional search string can filter the response set.
 Here is an example of listing tables:
 
 [source,python]
+.with Python:
 ----
 from kaskada import materialization
 from kaskada.api.session import LocalBuilder
@@ -128,6 +130,7 @@ materialization.list_materializations("Purchase")
 You can get a materialization using its name:
 
 [source,python]
+.with Python:
 ----
 from kaskada import materialization
 from kaskada.api.session import LocalBuilder
@@ -148,6 +151,7 @@ new expression.
 You can delete a materialization using its name:
 
 [source,python]
+.with Python:
 ----
 from kaskada import materialization
 from kaskada.api.session import LocalBuilder
@@ -158,6 +162,7 @@ materialization.delete_materialization("PurchaseStats")
 ----
 
 [source,bash]
+.with the CLI:
 ----
 ./kaskada-cli materialization delete -m PurchaseStats
 ----

--- a/docs-src/modules/developing/pages/materializations.adoc
+++ b/docs-src/modules/developing/pages/materializations.adoc
@@ -68,7 +68,7 @@ materializations:
 ----
 ////
 
-== Managing Materializations with Python
+== Managing Materializations
 
 === Creating a Materialization
 
@@ -155,6 +155,11 @@ from kaskada.api.session import LocalBuilder
 session = LocalBuilder().build()
 
 materialization.delete_materialization("PurchaseStats")
+----
+
+[source,bash]
+----
+./kaskada-cli materialization delete -m PurchaseStats
 ----
 
 Deleting a materialization does not delete any data persisted in the

--- a/docs-src/modules/developing/pages/tables.adoc
+++ b/docs-src/modules/developing/pages/tables.adoc
@@ -32,6 +32,7 @@ xref:reference:expected-file-format[Expected File Format]
 Here is an example of creating a table:
 
 [source,python]
+.with Python:
 ----
 from kaskada import table
 from kaskada.api.session import LocalBuilder
@@ -68,6 +69,7 @@ optional search string can filter the results.
 Here is an example of listing tables:
 
 [source,python]
+.with Python:
 ----
 from kaskada import table
 from kaskada.api.session import LocalBuilder
@@ -82,6 +84,7 @@ table.list_tables()
 You can get a table using its name:
 
 [source,python]
+.with Python:
 ----
 from kaskada import table
 from kaskada.api.session import LocalBuilder
@@ -101,6 +104,7 @@ and then re-creating it with a new expression.
 You can delete a table using its name:
 
 [source,python]
+.with Python:
 ----
 from kaskada import table
 from kaskada.api.session import LocalBuilder
@@ -111,6 +115,7 @@ table.delete_table(table = "Purchase")
 ----
 
 [source,bash]
+.with the CLI:
 ----
 ./kaskada-cli table delete -t Purchase
 ----

--- a/docs-src/modules/developing/pages/tables.adoc
+++ b/docs-src/modules/developing/pages/tables.adoc
@@ -3,7 +3,7 @@
 Kaskada stores data in _tables_. Tables consist of multiple rows, and
 each row is a value of the same type.
 
-== Managing tables with Python
+== Managing tables
 
 === Creating a Table
 
@@ -110,6 +110,11 @@ session = LocalBuilder().build()
 table.delete_table(table = "Purchase")
 ----
 
+[source,bash]
+----
+./kaskada-cli table delete -t Purchase
+----
+
 [WARNING]
 ====
 Note that deleting a table also deletes any events uploaded to it.
@@ -132,7 +137,7 @@ session = LocalBuilder().build()
 table.delete_table(table = "Purchase", force = True)
 ----
 
-== Managing tables with the CLI
+== Managing tables with the CLI and Spec files
 
 The CLI manages Kaskada resources declaratively by managing spec files.
 A spec file is a YAML file describing a set of Kaskada resources, for examples tables and views.
@@ -142,7 +147,7 @@ A spec file is a YAML file describing a set of Kaskada resources, for examples t
 The CLI uses a "declarative" API - rather than modifying resources directly you describe the desired state of Kaskada, and the `kaskada-cli sync` command makes whatever changes are needed to achieve this state.
 To create a table, add the table's description to your spec file and run `kaskada-cli sync apply`.
 To update a table, change the table's description in your spec file and run `kaskada-cli sync apply`.
-It is not currently possible to delete a table using the CLI.
+To delete a table, see xref:reference:cli.adoc#deleting-a-table[Deleting a table].
 
 === The format of tables in a spec file.
 

--- a/docs-src/modules/developing/pages/views.adoc
+++ b/docs-src/modules/developing/pages/views.adoc
@@ -25,6 +25,7 @@ each user. This definition depends on business logic and might require
 some iteration to get just right.
 
 [source,python]
+.with Python:
 ----
 from kaskada import view
 from kaskada.api.session import LocalBuilder
@@ -95,6 +96,7 @@ optional search string can filter the response set.
 Here is an example of listing tables:
 
 [source,python]
+.with Python:
 ----
 from kaskada import view
 from kaskada.api.session import LocalBuilder
@@ -109,6 +111,7 @@ view.list_views("Purchase")
 You can get a view using its name:
 
 [source,python]
+.with Python:
 ----
 from kaskada import view
 from kaskada.api.session import LocalBuilder
@@ -128,6 +131,7 @@ view and then re-creating it.
 You can delete a view using its name:
 
 [source,python]
+.with Python:
 ----
 from kaskada import view
 from kaskada.api.session import LocalBuilder
@@ -138,6 +142,7 @@ view.delete_view("PurchaseStats")
 ----
 
 [source,bash]
+.with the CLI:
 ----
 ./kaskada-cli view delete -v PurchaseStats
 ----

--- a/docs-src/modules/developing/pages/views.adoc
+++ b/docs-src/modules/developing/pages/views.adoc
@@ -15,7 +15,7 @@ Views are useful any time you need to share or re-use expressions:
 * ML feature definitions
 
 
-== Managing views with Python
+== Managing views
 
 === Creating a View
 
@@ -137,19 +137,23 @@ session = LocalBuilder().build()
 view.delete_view("PurchaseStats")
 ----
 
+[source,bash]
+----
+./kaskada-cli view delete -v PurchaseStats
+----
 
-== Managing views with the CLI
+== Managing views with the CLI and Spec files
 
 The CLI manages Kaskada resources declaratively by managing spec files.
 A spec file is a YAML file describing a set of Kaskada resources, for examples tables and views.
 
-=== Creating, updating and deleting tables with the CLI
+=== Creating, updating and deleting views with the CLI
 
 
 The CLI uses a "declarative" API - rather than modifying resources directly you describe the desired state of Kaskada, and the `kaskada-cli sync` command makes whatever changes are needed to achieve this state.
-To create a table, add the table's description to your spec file and run `kaskada-cli sync apply`.
-To update a table, change the table's description in your spec file and run `kaskada-cli sync apply`.
-It is not currently possible to delete a table using the CLI.
+To create a view, add the view's description to your spec file and run `kaskada-cli sync apply`.
+To update a view, change the view's description in your spec file and run `kaskada-cli sync apply`.
+To delete a view, see xref:deleting-a-view[Deleting a view].
 
 === The format of views in a spec file.
 

--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -157,7 +157,7 @@ section of the "Tables"] page.
 curl -L "https://drive.google.com/uc?export=download&id=1SLdIw9uc0RGHY-eKzS30UBhN0NJtslkk" -o purchase.parquet
 
 # Load the file into the Purchase table (which was created in the previous step)
-./kaskada-cli load \
+./kaskada-cli table load \
     --table Purchase \
     --file-path file://${PWD}/purchase.parquet
 ----
@@ -262,3 +262,18 @@ EOS
 
 For more help writing queries, see xref:developing:queries.adoc[Reference -
 Writing Queries]
+
+== Cleaning up
+
+When you're done with this tutorial, you can delete the table you created in order to free up resources.
+
+[source,bash]
+----
+# Delete the Purchase table (which was created in the previous step)
+./kaskada-cli table delete --table Purchase
+----
+
+The table is deleted and any files loaded into it are removed from the system.
+
+For more help with tables, see xref:developing:tables.adoc[Reference -
+Tables]

--- a/wren/auth/api_client.go
+++ b/wren/auth/api_client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/kaskada-ai/kaskada/wren/ent"
 )
 
@@ -35,9 +36,19 @@ func (u *apiClient) GetOwner() *ent.Owner {
 
 // AddAPIClientToContext returns a context with the client attached
 func AddAPIClientToContext(ctx context.Context, client APIClient) context.Context {
+
+	// TODO: this doesn't work as expected.  Maybe the fields are getting added too late?
+	// add ids for request & payload logs
+	ctx = logging.InjectFields(ctx,
+		logging.Fields{
+			"owner_id", client.GetOwner().ID.String(),
+			"client_id", client.GetOwner().ClientID,
+		})
+
 	// Add the client-id to the context logger
 	contextLogger := log.Ctx(ctx).With().
 		Str("owner_id", client.GetOwner().ID.String()).
+		Str("client_id", client.GetOwner().ClientID).
 		Logger()
 	ctx = contextLogger.WithContext(ctx)
 	// Finally add the full client object


### PR DESCRIPTION
also:
* re organized the other cli code into per-section packages.
* changed the code to not send an empty client-id if no client-id flag is passed. This fixes an issue where the python client and the CLI were using different client-ids by default

closes #250 