### PR TITLE
Update docs to improve clarity and usability

### DIFF
--- a/docs-src/modules/ROOT/pages/loading-data.adoc
+++ b/docs-src/modules/ROOT/pages/loading-data.adoc
@@ -130,7 +130,10 @@ See xref:reference:expected-file-format[Expected File Format] for details.
 
 This loads the contents of the file to the Purchases table.
 
-The result of running `load()` is a `data_token_id``. The data token ID is a unique reference to the data currently stored in the system.
+The result of running `load` is a `data_token_id`. 
+The data token ID is a unique reference to the data currently stored in the system. 
+Data tokens repeatable queries: qeries performed against the same data token always run on the same input data
+
 
 [source,bash]
 ----

--- a/docs-src/modules/ROOT/pages/loading-data.adoc
+++ b/docs-src/modules/ROOT/pages/loading-data.adoc
@@ -132,7 +132,7 @@ This loads the contents of the file to the Purchases table.
 
 The result of running `load` is a `data_token_id`. 
 The data token ID is a unique reference to the data currently stored in the system. 
-Data tokens repeatable queries: qeries performed against the same data token always run on the same input data
+Data tokens enable repeatable queries: queries performed against the same data token always run on the same input data.
 
 
 [source,bash]

--- a/docs-src/modules/developing/pages/queries.adoc
+++ b/docs-src/modules/developing/pages/queries.adoc
@@ -16,15 +16,26 @@ To learn more about Fenl:
 Kaskada's query language builds on the lessons of 50+ years of query language design to provide a declarative, composable, easy-to-read, and type-safe way of describing computations related to time. 
 The following is a quick overview of the query language's main features and syntax.
 
+=== Viewing and filtering the contents of a table
+
+Kaskada queries are built by composing simple expressions. 
+Every expression returns a timeline.
+
+[source,Fenl]
+----
+Purchase | when(Purchase.amount > 10)
+----
+
+In this example we start with the expression `Purchase` (the timeline of all purchase events) then filter it using `xref:fenl:catalog.adoc#when[when()]`.
+The result is a timeline of purchase events whose amount is greater than 10.
+
 === Stateful aggregations
 
 Aggregate events to produce a continuous timeline whose value can be observed at arbitrary points in time.
 
 [source,Fenl]
 ----
-{
-  max_review_to_date: max(review.stars),
-}
+{ max_verified_review_to_date: Review.stars | when(Review.verified) | max() }
 ----
 
 [TIP]
@@ -35,16 +46,21 @@ Records allow one or more values to be grouped into a single row.
 You can create a record using the syntax `{key: value, key2: value2}`.
 ====
 
+In this example we first filter the timeline of `Review` events to only include verified reviews, then aggregate the filtered results using the `xref:fenl:catalog.adoc#max[max()]` aggregation.
+The resulting timeline describes the maximum number of stars as-of every point in time.
+
 === Automatic joins
 
-Every expression is associated with an “entity”, allowing tables and expressions to be automatically joined. Entities eliminate redundant boilerplate code.
+Every expression is associated with an xref:fenl:entities.adoc[entity], allowing tables and expressions to be automatically joined. Entities eliminate redundant boilerplate code.
 
 [source,Fenl]
 ----
-{
-  purchases_per_page_view: count(purchase) / count(pageview),
-}
+{ purchases_per_page_view: count(Purchase) / count(Pageview) }
 ----
+
+Here we've used the `xref:fenl:catalog.adoc#count[count()]` aggregation to divide the number of purchases up to each point in time by the number of pageviews up to the same point in time.
+The result is a timeline describing how each user's purchase-per-pageview changes over time.
+Since both the `Purchase` and `Pageview` tables have the same entity, we can easily combine them.
 
 === Event-based windowing
 
@@ -53,10 +69,13 @@ Collect events as you move through time, and aggregate them with respect to othe
 [source,Fenl]
 ----
 {
-  pageviews_since_last_purchase:  count(pageview, window=since(purchase)),
-  spend_since_last_review:        count(purchase, window=since(review)),
+  pageviews_since_last_purchase:  count(Pageview, window=since(Purchase)),
+  spend_since_last_review:        count(Purchase, window=since(Review)),
 }
 ----
+
+By default, aggregations are applied from the beginning of time, but here we've used the `xref:fenl:catalog.adoc#since[since()]` window function to configure the aggregation to reset each time there's a `Purchase` or `Review`, respectively.
+
 
 === Pipelined operations
 
@@ -66,21 +85,20 @@ Pipe syntax allows multiple operations to be chained together. Write your operat
 ----
 {
   largest_spend_over_2_purchases: purchase.amount
-  | when(purchase.category == "food") 
-  | sum(window=sliding(2, purchase.category == "food")) # Inner aggregation
+  | when(Purchase.category == "food") 
+  | sum(window=sliding(2, Purchase.category == "food")) # Inner aggregation
   | max()                                               # Outer aggregation
 }
 ----
 
-
 === Row generators
 
-Pivot from events to time-series. Unlike grouped aggregates, xref:fenl:catalog.adoc#tick-functions[tick generators] such as `daily()` produce rows even when there's no input, allowing you to react when something _doesn't_ happen.
+Pivot from events to time-series. Unlike grouped aggregates, xref:fenl:catalog.adoc#tick-functions[tick generators] such as `xref:fenl:catalog.adoc#daily[daily()]` produce rows even when there's no input, allowing you to react when something _doesn't_ happen.
 
 [source,Fenl]
 ----
 {
-  signups_per_hour: count(signups, window=since(daily()))
+  signups_per_hour: count(Signups, window=since(daily()))
   | when(daily())
   | mean()
 }
@@ -88,20 +106,18 @@ Pivot from events to time-series. Unlike grouped aggregates, xref:fenl:catalog.a
 
 === Continuous expressions
 
-Observe the value of aggregations at arbitrary points in time. Timelines are either “discrete” (instantaneous values or events) or “continuous” (values produced by a stateful aggregations). Continuous timelines let you combine aggregates computed from different event sources.
+Observe the value of aggregations at arbitrary points in time. Timelines are either “xref:fenl:continuity.adoc#discrete-expressions[discrete]” (instantaneous values or events) or “xref:fenl:continuity.adoc#continuous-expressions[continuous]” (values produced by a stateful aggregations). Continuous timelines let you combine aggregates computed from different event sources.
 
 [source,Fenl]
 ----
-let product_average = review.stars
-| with_key(review.product_id)
+let product_average = Review.stars
+| with_key(Review.product_id)
 | mean()
 
-in {
-  average_product_review: product_average | lookup(purchase.product_id)),
-}
+in { average_product_review: product_average | lookup(Purchase.product_id)) }
 ----
 
-In this example the `lookup` function is used to observe a value computed for a different entity.
+In this example the `xref:fenl:catalog.adoc#lookup[lookup()]` function is used to observe a value computed for a different entity.
 The variable `product_average` computes the average review using the product's ID as entity.
 The lookup starts with each `purchase`, then looks up the current value of the product's average review, for the procduct ID specified in the purchase.
 
@@ -111,14 +127,15 @@ Shifting values forward (but not backward) in time, allows you to combine differ
 
 [source,Fenl]
 ----
-let purchases_now = count(purchase)
+let purchases_now = count(Purchase)
 let purchases_yesterday =
    purchases_now | shift_by(days(1))
 
-in {
-  purchases_in_last_day: purchases_now - purchases_yesterday,
-}
+in { purchases_in_last_day: purchases_now - purchases_yesterday }
 ----
+
+In this example we take the timeline produced by `purchases_now` and move it forward in time by one day using the `xref:fenl:catalog.adoc#shift-by[shift_by()]` function. 
+We then subtract the shifted value from the original, unshifted value
 
 === Simple, composable syntax
 
@@ -129,8 +146,8 @@ It is functions all the way down. No global state, no dependencies to manage, an
 # How many big purchases happen each hour and where?
 let cadence = hourly()
 # Anything can be named and re-used
-let hourly_big_purchases = purchase
-| when(purchase.amount > 10)
+let hourly_big_purchases = Purchase
+| when(Purchase.amount > 10)
 # Filter anywhere 
 | count(window=since(cadence))
 # Aggregate anything
@@ -141,7 +158,7 @@ in {hourly_big_purchases}
 # Records are just another type
 | extend({
   # …modify them sequentially
-  last_visit_region: last(pageview.region)
+  last_visit_region: last(Pageview.region)
 })
 ----
 
@@ -165,7 +182,7 @@ To return final results, you must configure the `final-results` behavior:
 [source,Fenl]
 .Final queries with fenlmagic
 ----
-%%fenl --result_behavior final-results
+%%fenl --result-behavior final-results
 {
     time: Purchase.purchase_time,
     entity: Purchase.customer_id,

--- a/docs-src/modules/developing/pages/tables.adoc
+++ b/docs-src/modules/developing/pages/tables.adoc
@@ -7,27 +7,30 @@ each row is a value of the same type.
 
 === Creating a Table
 
-When creating a table, you must provide information about how each row
-should be interpreted. You must describe:
+Every table is associated with a schema which defines the structure of each event in the table.
+Schemas are inferred from the data you load into a table, however, some columns are required by Kaskada's data model.
+Every table must include a column identifying the xref:fenl:temporal-aggregation.adoc[time] and xref:fenl:entities.adoc[entity] associated with each row. 
 
-* The name of a column in your data that contains the time of each row
-(`time_column_name`). The time should refer to when the event occurred.
-* The name of a column in your data that contains the xref:fenl:entities.adoc[entity] key of each row
-(`entity_key_column_name`). The entity should identify a _thing_ in the
-world that each event is associated with. Don't worry too much about
-picking the "right" value here - it's easy to change the entity key in
-Fenl.
+When creating a table, you must tell Kaskada which columns contain the time and entity of each row:
 
+* The xref:fenl:temporal-aggregation.adoc[time] column is specified using the `time_column_name` parameter.
+  This parameter should identify a column name in the table's data which contains time values.
+  The time should refer to when the event occurred.
+* The xref:fenl:entities.adoc[entity] key is specified using the `entity_key_column_name` parameter.
+  This parameter should identify a column name in the table's data which contains the entity key value.
+  The entity key should identify a _thing_ in the world that each event is associated with.
+  Don't worry too much about picking the "right" value - it's easy to change the entity using the xref:fenl:catalog.adoc#with-key[`with_key()`] function.
 
-Optionally:
+You may additionally configure the table's behavior by specifying the following parameters:
 
-* An subsort column associated with each row (`subsort_column_name`).
-This value is used to order rows associated with the same time value.
-If no subsort column is provided, Kaskada will generate one.
-* A name describing the type of entity, for example "User" or "Purchase".
+* An subsort column associated with each row is specified using the `subsort_column_name` parameter.
+  This value is used to order rows associated with the same time value.
+  If no subsort column is provided, Kaskada will generate one.
+* The type of entity is specified using the `grouping_id` parameter.
+  The grouping ID specifies what kind of entity each event is associated with, for example "User" or "Purchase".
+  When combining events from different tables, events with the same entity key and grouping ID are treated as being part of the same entity.
 
-For more information about these fields, see:
-xref:reference:expected-file-format[Expected File Format]
+For more information about the expected structure of input files, see xref:ROOT:loading-data.adoc#file-format[Expected File Format]
 
 Here is an example of creating a table:
 

--- a/docs-src/modules/developing/pages/tables.adoc
+++ b/docs-src/modules/developing/pages/tables.adoc
@@ -14,10 +14,10 @@ Every table must include a column identifying the xref:fenl:temporal-aggregation
 When creating a table, you must tell Kaskada which columns contain the time and entity of each row:
 
 * The xref:fenl:temporal-aggregation.adoc[time] column is specified using the `time_column_name` parameter.
-  This parameter should identify a column name in the table's data which contains time values.
+  This parameter must identify a column name in the table's data which contains time values.
   The time should refer to when the event occurred.
 * The xref:fenl:entities.adoc[entity] key is specified using the `entity_key_column_name` parameter.
-  This parameter should identify a column name in the table's data which contains the entity key value.
+  This parameter must identify a column name in the table's data which contains the entity key value.
   The entity key should identify a _thing_ in the world that each event is associated with.
   Don't worry too much about picking the "right" value - it's easy to change the entity using the xref:fenl:catalog.adoc#with-key[`with_key()`] function.
 

--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -80,21 +80,22 @@ A spec file is a YAML file describing a set of Kaskada resources, for examples t
 We'll begin by creating a table.
 The first step is to create a spec file containing the table's definition.
 
-When creating a table, you must provide some information about how each
-row should be interpreted. You must describe:
+Every table is associated with a schema which defines the structure of each event in the table.
+Schemas are inferred from the data you load into a table, however, some columns are required by Kaskada's data model.
+Every table must include a column identifying the xref:fenl:temporal-aggregation.adoc[time] and xref:fenl:entities.adoc[entity] associated with each row. 
 
-* A field containing the time associated with each event
-(`time_column_name`). The time should refer to when the event occurred.
-* An initial xref:fenl:entities.adoc[entity] key associated with each row
-(`entity_key_column_name`). The entity should identify a _thing_ in the
-world that each event is associated with. Don't worry too much about
-picking the "right" value here - it's easy to change the entity key in
-Fenl.
-* An (optional) subsort column associated with each event (`subsort_column_name`).
-This value is used to order rows associated with the same time value.
+When creating a table, you must tell Kaskada which columns contain the time and entity of each row:
 
-For more information about these fields, see:
-xref:ROOT:loading-data.adoc#file-format[Expected File Format]
+* The xref:fenl:temporal-aggregation.adoc[time] column is specified using the `time_column_name` parameter.
+  This parameter should identify a column name in the table's data which contains time values.
+  The time should refer to when the event occurred.
+* The xref:fenl:entities.adoc[entity] key is specified using the `entity_key_column_name` parameter.
+  This parameter should identify a column name in the table's data which contains the entity key value.
+  The entity key should identify a _thing_ in the world that each event is associated with.
+  Don't worry too much about picking the "right" value - it's easy to change the entity using the xref:fenl:catalog.adoc#with-key[`with_key()`] function.
+
+For more information about configuring tables, see xref:developing:tables.adoc#creating-a-table[].
+For more information about the expected structure of input files, see xref:ROOT:loading-data.adoc#file-format[Expected File Format]
 
 [source,yaml]
 .spec.yaml

--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -87,10 +87,10 @@ Every table must include a column identifying the xref:fenl:temporal-aggregation
 When creating a table, you must tell Kaskada which columns contain the time and entity of each row:
 
 * The xref:fenl:temporal-aggregation.adoc[time] column is specified using the `time_column_name` parameter.
-  This parameter should identify a column name in the table's data which contains time values.
+  This parameter must identify a column name in the table's data which contains time values.
   The time should refer to when the event occurred.
 * The xref:fenl:entities.adoc[entity] key is specified using the `entity_key_column_name` parameter.
-  This parameter should identify a column name in the table's data which contains the entity key value.
+  This parameter must identify a column name in the table's data which contains the entity key value.
   The entity key should identify a _thing_ in the world that each event is associated with.
   Don't worry too much about picking the "right" value - it's easy to change the entity using the xref:fenl:catalog.adoc#with-key[`with_key()`] function.
 

--- a/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
@@ -125,10 +125,10 @@ Every table must include a column identifying the xref:fenl:temporal-aggregation
 When creating a table, you must tell Kaskada which columns contain the time and entity of each row:
 
 * The time column is specified using the `time_column_name` parameter.
-  This parameter should identify a column name in the table's data which contains time values.
+  This parameter must identify a column name in the table's data which contains time values.
   The time should refer to when the event occurred.
 * The xref:fenl:entities.adoc[entity] key is specified using the `entity_key_column_name` parameter.
-  This parameter should identify a column name in the table's data which contains the entity key value.
+  This parameter must identify a column name in the table's data which contains the entity key value.
   The entity key should identify a _thing_ in the world that each event is associated with.
   Don't worry too much about picking the "right" value - it's easy to change the entity using the `xref:fenl:catalog.adoc#with-key[with_key()]` function.
 

--- a/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
@@ -118,19 +118,22 @@ each row is a value of the same type.
 
 === Creating a Table
 
-When creating a table, you must provide some information about how each
-row should be interpreted. You must describe:
+Every table is associated with a schema which defines the structure of each event in the table.
+Schemas are inferred from the data you load into a table, however, some columns are required by Kaskada's data model.
+Every table must include a column identifying the xref:fenl:temporal-aggregation.adoc[time] and xref:fenl:entities.adoc[entity] associated with each row. 
 
-* The name of a column in your data that contains the time of each row
-(`time_column_name`). The time should refer to when the event occurred.
-* The name of a column in your data that contains the xref:fenl:entities.adoc[entity] key of each row
-(`entity_key_column_name`). The entity should identify a _thing_ in the
-world that each event is associated with. Don't worry too much about
-picking the "right" value here - it's easy to change the entity key in
-Fenl.
+When creating a table, you must tell Kaskada which columns contain the time and entity of each row:
 
-For more information about these fields, see:
-xref:ROOT:loading-data.adoc#file-format[Expected File Format]
+* The time column is specified using the `time_column_name` parameter.
+  This parameter should identify a column name in the table's data which contains time values.
+  The time should refer to when the event occurred.
+* The xref:fenl:entities.adoc[entity] key is specified using the `entity_key_column_name` parameter.
+  This parameter should identify a column name in the table's data which contains the entity key value.
+  The entity key should identify a _thing_ in the world that each event is associated with.
+  Don't worry too much about picking the "right" value - it's easy to change the entity using the `xref:fenl:catalog.adoc#with-key[with_key()]` function.
+
+For more information about configuring tables, see xref:developing:tables.adoc#creating-a-table[].
+For more information about the expected structure of input files, see xref:ROOT:loading-data.adoc#file-format[Expected File Format]
 
 [source,python]
 ----
@@ -193,7 +196,7 @@ Now that we've created a table, we're ready to load some data into it.
 Data can be loaded into a table in multiple ways. In this example we'll
 load the contents of a Parquet file into the table. To learn about
 the different ways data can be loaded into a table, see the
-xref:ROOT:loading-data.adoc["Loading Data"]
+xref:ROOT:loading-data.adoc[Loading Data]
 section of the docs.
 
 [source,python]
@@ -211,9 +214,11 @@ purchases_path = "/absolute/path/to/purchases.parquet"
 table.load(table_name = "Purchase", file = purchases_path)
 ----
 
-The result of running `load` is a `data_token_id`. The
-data token ID is a unique reference to the data currently stored in the
-system.
+The result of running `load` is a `data_token_id`. 
+The data token ID is a unique reference to the data currently stored in the system. 
+Data tokens repeatable queries: qeries performed against the same data token always run on the same input data
+
+
 
 [source,json]
 ----
@@ -224,54 +229,6 @@ request_details {
 ----
 
 The file is transferred to Kaskada and it's content added to the table.
-
-=== Inspecting the Table's Contents
-
-To verify the file was loaded as expected you can use the table list
-endpoint to see all the tables defined for your user and the files
-loaded into each:
-
-[source,python]
-----
-from kaskada import table
-from kaskada.api.session import LocalBuilder
-
-session = LocalBuilder().build()
-
-table.list_tables()
-----
-
-`list_tables` shows all the tables accessible by the user and returns a
-`list` of `table`. The table created above is shown here:
-
-[source,json]
-----
-tables {
-  table_id: "76b***2e5"
-  table_name: "Purchase"
-  time_column_name: "purchase_time"
-  entity_key_column_name: "customer_id"
-  subsort_column_name: "subsort_id"
-  create_time {
-    seconds: 1634067588
-    nanos: 312567086
-  }
-  update_time {
-    seconds: 1634067603
-    nanos: 70745776
-  }
-  version: 1
-}
-request_details {
-  request_id: "fe6bed41fa29cea6ca85fe20bea6ef4c"
-}
-----
-
-After executing this block, all tables that have been defined are
-returned.
-
-For more help with tables and loading data, see xref:developing:tables.adoc[Reference -
-Tables]
 
 == Querying Data
 
@@ -297,12 +254,6 @@ query will return all of the columns and rows contained in a table:
 Purchase
 ----
 
-[NOTE]
-====
-This table is intentionally small so that you can get to know
-queries with Kaskada.
-====
-
 It can be helpful to limit your results to a single entity.
 This makes it easier to see how a single entity changes over time.
 
@@ -313,70 +264,98 @@ Purchase | when(Purchase.customer_id == "patrick")
 ----
 
 In this example, we build a pipeline of functions using the `|` character.
-Pipelines are an easy way to use the results of one expression as the input to another expresion.
-In this example we begin with the timeline produced by the table `Purchase`, then filter it to the set of times where the purchase's customer is `"patrick"`. 
+We begin with the timeline produced by the table `Purchase`, then filter it to the set of times where the purchase's customer is `"patrick"` using the `xref:fenl:catalog.adoc#when[when()]` function.
 
-As you begin to better understand your data you can start using
-aggregations over your data such as the `max()` function:
-
-[source,Fenl]
-----
-%%fenl
-{
-   max_purchase: Purchase.amount | max(),
-} | when(Purchase.customer_id == "patrick") 
-----
-
-[IMPORTANT]
-====
-These results may be surprising if you were expecting a single value,
-this is a feature, not a bug!
-
-Computations in Fenl are temporal: they produce a time-series of values
-describing the full history of a computation's results. Temporal
-computation allows Fenl to capture what an expression's value would have
-been at arbitrary times in the past.
-
-Fenl values can time-travel forward through time. Time travel allows
-combining the result of different computations at different points in
-time. Because values can only travel forward in time, Fenl prevents
-information about the future from "leaking" into the past.
-
-Read more in the xref:fenl:language-guide.adoc[Fenl
-Language Guide]
-====
-
-Now we can start building up our features. To reduce the set of columns
-output in your query, you can define a record with the curly braces
-`{ }` and name the columns with a label shown on the left of the `:` in
-the below query. In order to debug your features, we recommend including
-the time and the entity with each query so that you can walk through the
-results in time:
+Kaskada's query language provides a rich set of operations for reasoning about time.
+Here's a more sophisticated example that touches on many of the unique features of Kaskada queries:
 
 [source,Fenl]
 ----
 %%fenl
-{
-    time: Purchase.purchase_time,
-    entity: Purchase.customer_id,
-    max_amount: Purchase.amount | max(),
-    min_amount: Purchase.amount | min(),
-}
+# How many big purchases happen each hour and where?
+let cadence = hourly()
+
+# Anything can be named and re-used
+let hourly_big_purchases = purchase
+| when(Purchase.amount > 10)
+
+# Filter anywhere
+| count(window=since(cadence))
+
+# Aggregate anything
+| when(cadence)
+
+# Shift timelines relative to each other
+let purchases_now = count(Purchase)
+let purchases_yesterday =
+   purchases_now | shift_by(days(1))
+
+# Records are just another type
+in { hourly_big_purchases, purchases_in_last_day: purchases_now - purchases_yesterday }
+| extend({
+  # …modify them sequentially
+  last_visit_region: last(Pageview.region)
+})
+----
+
+For more information about writing queries, see xref:developing:queries.adoc[Reference -
+Queries]
+
+=== Configuring queries
+
+A given query can be computed in different ways.
+You can configure how a query is executed by providing flags to the `%%fenl` block.
+
+==== Changing how the result timeline is converted to a table
+
+You can either return a table describing each change in the timeline, or a table describing the "final" value of the timeline.
+By default, queries return each change in the timeline.
+
+You can change the results to only include the final values:
+
+[source,Fenl]
+----
+%%fenl --result-behavior final-results
+Purchase | when(Purchase.customer_id == "patrick")
+----
+
+==== Limiting how many rows are returned
+
+You can limit the number of rows returned from a query:
+
+[source,Fenl]
+----
+%%fenl --preview-rows 10
+Purchase | when(Purchase.customer_id == "patrick")
 ----
 
 [TIP]
 ====
-The result of a previous cell in Jupyter is available to be saved
-by setting a variable to the result temporarily stored as `_`. You can
-then interact with these results at a typical dataframe such as
-displaying the columns or plotting a histogram:
+This may return more rows that you asked for.
+Kaskada computes data in batches. 
+When you configure `--preview-rows` Kaskada stops processing at the end of a batch once the given number of rows have been computed, and returns all the rows that were computed.
 ====
 
-[source,IPython]
+==== Assigning results to a variable
+
+To capture the result of a query and assign it to the variable `query_result`:
+
+[source,Fenl]
 ----
-df_explore = _
-df_explore.dataframe.columns
+%%fenl --var query_result
+Purchase | when(Purchase.customer_id == "patrick")
 ----
 
-For more help writing queries, see xref:developing:queries.adoc[Reference -
-Writing Queries]
+You can now inspect the resulting dataframe, or the original query string:
+
+[source,Python]
+----
+# The result dataframe
+query_result.dataframe
+
+# The original query expression
+query_result.expression
+----
+
+For more information about configuring queries, see xref:developing:queries.adoc#configuring-how-queries-are-computed[Reference -
+Configuring Queries]

--- a/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
@@ -216,7 +216,7 @@ table.load(table_name = "Purchase", file = purchases_path)
 
 The result of running `load` is a `data_token_id`. 
 The data token ID is a unique reference to the data currently stored in the system. 
-Data tokens repeatable queries: qeries performed against the same data token always run on the same input data
+Data tokens enable repeatable queries: queries performed against the same data token always run on the same input data.
 
 
 


### PR DESCRIPTION
* Explain what data tokens are for everywhere they’re mentioned
* Fix “--result_behavior” in docs
* Start query examples with a table list (ie “Purchase”)
* Show “when” inside brackets and out early on
* Cross-link to function catalog anywhere we’re introducing syntax