### PR TITLE
Update Log Output Files (#274)

### DIFF
--- a/clients/python/src/kaskada/api/api_utils.py
+++ b/clients/python/src/kaskada/api/api_utils.py
@@ -7,7 +7,11 @@ from typing import List
 
 
 def run_subprocess(cmd: List[str], stderr: Path, stdout: Path):
-    return subprocess.Popen(cmd, stderr=open(stderr, "w"), stdout=open(stdout, "w"))
+    return subprocess.Popen(
+        cmd,
+        stderr=open(stderr, "w", encoding="utf-8"),
+        stdout=open(stdout, "w", encoding="utf-8"),
+    )
 
 
 def check_socket(endpoint: str) -> bool:

--- a/clients/python/src/kaskada/api/session.py
+++ b/clients/python/src/kaskada/api/session.py
@@ -2,8 +2,8 @@ import logging
 import os
 import sys
 import time
-import uuid
 from abc import ABC
+from datetime import datetime
 from pathlib import Path
 from subprocess import Popen
 from typing import Any, Dict, Optional, Tuple
@@ -20,14 +20,12 @@ class Session:
         self,
         endpoint: str,
         is_secure: bool,
-        name: str,
         client_id: Optional[str] = None,
         manager_process: Optional[Popen] = None,
         engine_process: Optional[Popen] = None,
     ) -> None:
         self._endpoint = endpoint
         self._is_secure = is_secure
-        self._name = name
         self._client_id = client_id
         self._client = self.connect()
         self._manager_process = manager_process
@@ -71,13 +69,13 @@ class Builder(ABC):
         self,
         endpoint: Optional[str] = None,
         is_secure: Optional[bool] = None,
-        name: str = str(uuid.uuid4()),
+        name: Optional[str] = None,
         client_id: Optional[str] = None,
     ) -> None:
         super().__init__()
         self._endpoint: Optional[str] = endpoint
         self._is_secure: Optional[bool] = is_secure
-        self._name: str = name
+        self._name: Optional[str] = name
         self._client_id: Optional[str] = client_id
 
     def endpoint(self, endpoint: str, is_secure: bool):
@@ -167,15 +165,17 @@ class LocalBuilder(Builder):
             raise ValueError("no path provided and KASKADA_PATH was not set")
         if self._log_path is None:
             raise ValueError("no log path provided and KASKADA_LOG_PATH was not set")
-        log_path = Path(
-            "{}/{}/{}".format(self._path, self._log_path, self._name)
-        ).expanduser()
+        log_path = Path("{}/{}".format(self._path, self._log_path)).expanduser()
+        if self._name is not None:
+            log_path = log_path / self._name
         log_path.mkdir(parents=True, exist_ok=True)
         return log_path / file_name
 
-    def __get_std_paths(self, prefix: str) -> Tuple[Path, Path]:
-        stderr = self.__get_log_path(f"{prefix}_stderr.txt")
-        stdout = self.__get_log_path(f"{prefix}_stdout.txt")
+    def __get_std_paths(self, service_name: str) -> Tuple[Path, Path]:
+        current_time = datetime.now()
+        timestamp_format = current_time.strftime("%Y-%m-%dT%H-%M-%S")
+        stderr = self.__get_log_path(f"{timestamp_format}-{service_name}-stderr.log")
+        stdout = self.__get_log_path(f"{timestamp_format}-{service_name}-stdout.log")
         return (stderr, stdout)
 
     def __get_binary_path(self) -> Path:
@@ -203,14 +203,14 @@ class LocalBuilder(Builder):
         engine_cmd = [engine_binary_path, engine_command]
         logger.debug(f"Engine start command: {engine_cmd}")
         logger.info("Initializing manager process")
-        logger.info(f"Logging manager STDOUT to {manager_std_out}")
-        logger.info(f"Logging manager STDERR to {manager_std_err}")
+        logger.info(f"Logging manager STDOUT to {manager_std_out.absolute()}")
+        logger.info(f"Logging manager STDERR to {manager_std_err.absolute()}")
         manager_process = api_utils.run_subprocess(
             manager_cmd, manager_std_err, manager_std_out
         )
         logger.info("Initializing engine process")
-        logger.info(f"Logging engine STDOUT to {engine_std_out}")
-        logger.info(f"Logging engine STDERR to {engine_std_err}")
+        logger.info(f"Logging engine STDOUT to {engine_std_out.absolute()}")
+        logger.info(f"Logging engine STDERR to {engine_std_err.absolute()}")
         engine_process = api_utils.run_subprocess(
             engine_cmd, engine_std_err, engine_std_out
         )
@@ -255,7 +255,6 @@ class LocalBuilder(Builder):
         return Session(
             self._endpoint,
             self._is_secure,
-            self._name,
             client_id=self._client_id,
             manager_process=manager_process,
             engine_process=engine_process,
@@ -267,6 +266,4 @@ class RemoteBuilder(Builder):
         super().__init__()
 
     def build(self):
-        return Session(
-            self._endpoint, self._is_secure, self._name, client_id=self._client_id
-        )
+        return Session(self._endpoint, self._is_secure, client_id=self._client_id)

--- a/clients/python/tests/api/test_session.py
+++ b/clients/python/tests/api/test_session.py
@@ -8,7 +8,6 @@ def test_builder_defaults():
     assert builder._endpoint is None
     assert builder._is_secure is None
     assert builder._client_id is None
-    assert builder._name is not None
 
 
 def test_builder_set_endpoint_sets_endpoint_and_is_secure():
@@ -18,7 +17,6 @@ def test_builder_set_endpoint_sets_endpoint_and_is_secure():
     assert builder._endpoint == endpoint
     assert builder._is_secure == is_secure
     assert builder._client_id is None
-    assert builder._name is not None
 
 
 def test_builder_set_name_sets_name():
@@ -38,7 +36,6 @@ def test_local_builder_defaults():
     assert builder._endpoint == session.KASKADA_ENDPOINT_DEFAULT
     assert builder._is_secure == session.KASKADA_IS_SECURE_DEFAULT
     assert builder._client_id is None
-    assert builder._name is not None
     assert builder._path == session.LocalBuilder.KASKADA_PATH_DEFAULT
     assert builder._bin_path == session.LocalBuilder.KASKADA_BIN_PATH_DEFAULT
     assert builder._log_path == session.LocalBuilder.KASKADA_LOG_PATH_DEFAULT


### PR DESCRIPTION
# Description

Updates the logging for the Manager and the Engine to output to: ~~`~/.cache/kaskada/logs/<service_name>/<service_name>-<stderr/std-out>-<timestamp>.log`~~
`~/.cache/kaskada/logs/<timestamp>-<service_name>-<std-err/std-out>.log`. 

Example:
* `~/.cache/kaskada/logs/2023-05-02T18-11-25-engine-stderr.log`
* `~/.cache/kaskada/logs/2023-05-02T18-11-25-engine-stdout.log`

