### PR TITLE
(ci) fix typo: should-skip => should_skip

### DIFF
--- a/.github/workflows/reusable_ci_rust.yml
+++ b/.github/workflows/reusable_ci_rust.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     outputs: 
-      should-skip:
+      should_skip:
         description: "True if this workflow inferred that changes do not need to be build, false otherwise"
         value: ${{ jobs.rust_skip.outputs.should_skip }}
   workflow_dispatch:

--- a/.github/workflows/reusable_ci_wren.yml
+++ b/.github/workflows/reusable_ci_wren.yml
@@ -3,7 +3,7 @@
 on:
   workflow_call:
     outputs:
-      should-skip:
+      should_skip:
         description: "True if this workflow inferred that changes do not need to be build, false otherwise"
         value: ${{ jobs.wren_skip.outputs.should_skip }}
   workflow_dispatch:


### PR DESCRIPTION
CI integration jobs were not being skipped for PRs that did not alter any code relevant to sparrow or wren due to a typo in YAML. 