### PR TITLE
docs: execute command cli

### DIFF
--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -73,7 +73,7 @@ To verify they're installed correctly and executable, try running the following 
 
 [source,bash]
 ----
-kaskada-cli sync export --all
+./kaskada-cli sync export --all
 ----
 
 You should see output similar to the following:


### PR DESCRIPTION
Updates the cli docs to run the local `./` to match the other usages of the cli.