### PR TITLE
docs: load data cli call (#327)

### DIFF
--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -191,8 +191,8 @@ curl -L "https://drive.google.com/uc?export=download&id=1SLdIw9uc0RGHY-eKzS30UBh
 
 # Load the file into the Purchase table (which was created in the previous step)
 ./kaskada-cli table load \
-    --table Purchase \
-    --file-path file://${PWD}/purchase.parquet
+     Purchase \
+     file://${PWD}/purchase.parquet
 ----
 
 The file's content is added to the table.


### PR DESCRIPTION
Previously documented:
```
./kaskada-cli table load \
    --table Purchase \
    --file-path file://${PWD}/purchase.parquet
```

Result:
```
Error: unknown flag: --table
Usage:
  cli table load "table_name" "file_uri" [flags]

Flags:
  -h, --help          help for load
  -t, --type string   (Optional) The type of file to load.  Either 'parquet' or 'csv'.  Defaults to the file extension or 'parquet'.
```

New Command:
```
./kaskada-cli table load \
     Purchase \
     file://${PWD}/purchase.parquet
```

Result:
```
Successfully loaded "purchase.parquet" into "Purchase" table
```

Closes #327.