### PR TITLE
docs: Initial input/output page

### DIFF
--- a/docs-src/modules/integrating/nav.adoc
+++ b/docs-src/modules/integrating/nav.adoc
@@ -1,4 +1,4 @@
-* Integrating
+* xref:index.adoc[]
 ** xref:apache-pulsar.adoc[Apache Pulsar]
 ** xref:apache-cassandra.adoc[Apache Cassandra]
 ** xref:redis.adoc[Redis]

--- a/docs-src/modules/integrating/pages/index.adoc
+++ b/docs-src/modules/integrating/pages/index.adoc
@@ -1,0 +1,10 @@
+= Input / Output
+
+Kaskada supports a variety of input sources and output sinks.
+For details on using a specific connector, refer to the corresponding page.
+
+** xref:apache-pulsar.adoc[Apache Pulsar] is supported as a source and sink.
+** xref:apache-cassandra.adoc[Apache Cassandra] is supported as a destination using the Apache Pulsar sink and a Pulsar to Cassandra connector.
+** xref:redis.adoc[Redis] is supported as a destination using the Apache Pulsar sink and a Pulsar to Redis connector.
+** xref:aws-redshift.adoc[AWS Redshift] is supported as a destination using the Parquet sink, followed by loading the Parquet files into Redshift.
+** xref:snowflake.adoc[Snowflake] is supported as a destination using the Parquet sink, followed by loading the Parquet files into Snowflake.


### PR DESCRIPTION
Create an initial list of supported sources and sinks.

We should probably include the object store destination here, but this is meant as a starting place so that we have a convenient place to link when saying things like "Kaskada supports a variety of sources and sinks".