### PR TITLE
Update the Dockerfile Notebook Version to 0.1.7

### DIFF
--- a/Dockerfile.notebook
+++ b/Dockerfile.notebook
@@ -18,5 +18,4 @@ WORKDIR ${HOME}
 RUN pip install pulsar-client
 
 # Install the kaskada python client
-RUN pip install kaskada==0.1.1a9
-
+RUN pip install kaskada==0.1.7


### PR DESCRIPTION
Updates the Kaskada client to version 0.1.7 in the dockerfile notebook.

Q: Do we need to push a new image somehow to ghcr?