### PR TITLE
updated logging formats of both processes to be more similar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,9 +5691,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-opentelemetry = "0.18.0"
 tracing-serde = "0.1.3"
-tracing-subscriber = { version = "0.3.16", features = [
+tracing-subscriber = { version = "0.3.17", features = [
 	"env-filter",
 	"fmt",
 	"json",

--- a/clients/python/src/kaskada/api/session.py
+++ b/clients/python/src/kaskada/api/session.py
@@ -207,7 +207,10 @@ class LocalBuilder(Builder):
 
         manager_cmd = [str(manager_binary_path)] + self.__get_manager_configs_as_args()
         logger.debug(f"Manager start command: {manager_cmd}")
-        engine_cmd = [engine_binary_path, engine_command] + self.__get_engine_configs_as_args()
+        engine_cmd = [
+            engine_binary_path,
+            engine_command,
+        ] + self.__get_engine_configs_as_args()
         logger.debug(f"Engine start command: {engine_cmd}")
         logger.info("Initializing manager process")
         logger.info(f"Logging manager STDOUT to {manager_std_out.absolute()}")

--- a/clients/python/src/kaskada/api/session.py
+++ b/clients/python/src/kaskada/api/session.py
@@ -128,7 +128,8 @@ class LocalBuilder(Builder):
         self._download = (
             os.getenv(LocalBuilder.KASKADA_DISABLE_DOWNLOAD_ENV, "false") != "true"
         )
-        self._manager_configs: Dict[str, Any] = {}
+        self._manager_configs: Dict[str, Any] = {"-no-color": "1"}
+        self._engine_configs: Dict[str, Any] = {"--log-no-color": "1"}
 
     def path(self, path: str):
         self._path = path
@@ -157,6 +158,12 @@ class LocalBuilder(Builder):
     def __get_manager_configs_as_args(self):
         configs = []
         for key, value in self._manager_configs.items():
+            configs.append(f"{key}={value}")
+        return configs
+
+    def __get_engine_configs_as_args(self):
+        configs = []
+        for key, value in self._engine_configs.items():
             configs.append(f"{key}={value}")
         return configs
 
@@ -200,7 +207,7 @@ class LocalBuilder(Builder):
 
         manager_cmd = [str(manager_binary_path)] + self.__get_manager_configs_as_args()
         logger.debug(f"Manager start command: {manager_cmd}")
-        engine_cmd = [engine_binary_path, engine_command]
+        engine_cmd = [engine_binary_path, engine_command] + self.__get_engine_configs_as_args()
         logger.debug(f"Engine start command: {engine_cmd}")
         logger.info("Initializing manager process")
         logger.info(f"Logging manager STDOUT to {manager_std_out.absolute()}")

--- a/clients/python/tests/api/test_session.py
+++ b/clients/python/tests/api/test_session.py
@@ -40,7 +40,8 @@ def test_local_builder_defaults():
     assert builder._bin_path == session.LocalBuilder.KASKADA_BIN_PATH_DEFAULT
     assert builder._log_path == session.LocalBuilder.KASKADA_LOG_PATH_DEFAULT
     assert builder._download == True
-    assert builder._manager_configs == {}
+    assert builder._manager_configs == {'-no-color': '1'}
+    assert builder._engine_configs == {'--log-no-color': '1'}
 
 
 def test_local_builder_set_path_sets_path():

--- a/crates/sparrow-main/src/snapshots/sparrow_main__tests__main_help_stdout.snap
+++ b/crates/sparrow-main/src/snapshots/sparrow_main__tests__main_help_stdout.snap
@@ -39,6 +39,14 @@ Options:
           
           [env: SPARROW_LOG_JSON=]
 
+      --log-no-color <LOG_NO_COLOR>
+          Whether to disable color output in logs.
+          
+          Set to `1` to disable color output.
+          
+          [env: NO_COLOR=]
+          [default: 0]
+
       --disable-log-panic-handler
           Enables a custom panic handler which logs panics.
           

--- a/crates/sparrow-main/src/tracing_setup.rs
+++ b/crates/sparrow-main/src/tracing_setup.rs
@@ -50,6 +50,12 @@ pub struct TracingOptions {
     /// messages and omit parent spans information.
     #[arg(long, env = "SPARROW_LOG_JSON")]
     log_json: bool,
+
+    /// Whether to disable color output in logs.
+    /// 
+    /// Set to `1` to disable color output.
+    #[arg(long, default_value = "0", env = "NO_COLOR")]
+    log_no_color: i8,
 }
 
 impl TracingOptions {
@@ -106,14 +112,14 @@ pub fn setup_tracing(config: &TracingOptions) {
     // since the type of logs (JSON or not) affects the type of the
     // format layer and registry.
     if config.log_json {
-        let fmt_layer = tracing_subscriber::fmt::layer().event_format(RequestIdFormat);
+        let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(config.log_no_color != 1).event_format(RequestIdFormat);
         registry
             .with(fmt_layer)
             .with(config.create_tracer())
             .try_init()
             .unwrap();
     } else {
-        let fmt_layer = tracing_subscriber::fmt::layer().with_target(false);
+        let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(config.log_no_color != 1).with_target(false);
         registry
             .with(fmt_layer)
             .with(config.create_tracer())

--- a/crates/sparrow-main/src/tracing_setup.rs
+++ b/crates/sparrow-main/src/tracing_setup.rs
@@ -52,7 +52,7 @@ pub struct TracingOptions {
     log_json: bool,
 
     /// Whether to disable color output in logs.
-    /// 
+    ///
     /// Set to `1` to disable color output.
     #[arg(long, default_value = "0", env = "NO_COLOR")]
     log_no_color: i8,
@@ -112,14 +112,18 @@ pub fn setup_tracing(config: &TracingOptions) {
     // since the type of logs (JSON or not) affects the type of the
     // format layer and registry.
     if config.log_json {
-        let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(config.log_no_color != 1).event_format(RequestIdFormat);
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(config.log_no_color != 1)
+            .event_format(RequestIdFormat);
         registry
             .with(fmt_layer)
             .with(config.create_tracer())
             .try_init()
             .unwrap();
     } else {
-        let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(config.log_no_color != 1).with_target(false);
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(config.log_no_color != 1)
+            .with_target(false);
         registry
             .with(fmt_layer)
             .with(config.create_tracer())

--- a/crates/sparrow-main/src/tracing_setup/request_id_format.rs
+++ b/crates/sparrow-main/src/tracing_setup/request_id_format.rs
@@ -4,7 +4,7 @@ use opentelemetry::trace::TraceContextExt;
 use serde::ser::{SerializeMap, Serializer as _};
 use tracing::{Event, Subscriber};
 use tracing_opentelemetry::OtelData;
-use tracing_serde::{AsSerde, SerdeMapVisitor};
+use tracing_serde::SerdeMapVisitor;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::{LookupSpan, SpanRef};
@@ -32,8 +32,8 @@ where
             let mut serializer = serde_json::Serializer::new(WriteAdaptor::new(&mut writer));
 
             let mut serializer = serializer.serialize_map(None)?;
+            serializer.serialize_entry("level", &meta.level().as_str().to_lowercase())?;
             serializer.serialize_entry("timestamp", &chrono::Utc::now())?;
-            serializer.serialize_entry("level", &meta.level().as_serde())?;
             serializer.serialize_entry("line", &meta.line())?;
             serializer.serialize_entry("module", &meta.module_path())?;
             serializer.serialize_entry("target", meta.target())?;

--- a/wren/main.go
+++ b/wren/main.go
@@ -59,6 +59,7 @@ var (
 	objectStorePath           = flag.String("object-store-path", "./data", "the path or prefix for storing data objects. can be a relative path if the `object-store-type` is `local`.")
 
 	debug                    = flag.Bool("debug", false, "sets log level to debug")
+	debugDB                  = flag.Bool("debug-db", false, "logs database debug info")
 	debugGrpc                = flag.Bool("debug-grpc", false, "logs grpc connection debug info")
 	defaultClientID          = flag.String("default-client-id", "default-client-id", "the default client-id to use when one isn't passed in the request")
 	env                      = flag.String("env", "prod", "the environment the service is running in")
@@ -70,6 +71,7 @@ var (
 	fileServiceUseTLS        = flag.Bool("file-service-use-tls", false, "should TLS be used to connect to the file service")
 	logFormatJson            = flag.Bool("log-format-json", false, "if enabled, logs will be outputted in json")
 	logHealthCheck           = flag.Bool("log-health-check", false, "if enabled, output logs for health-check API calls")
+	logNoColor               = flag.Int("no-color", 0, "set to `1` to disable color output in logs")
 	prepareParallelizeFactor = flag.Int("prepare-parallelize-factor", 2, "the number of parallel prepare requests that are made per api request")
 	prepareServiceHost       = flag.String("prepare-service-host", "localhost", "the hostname of the prepare service")
 	prepareServicePort       = flag.Int("prepare-service-port", 50052, "the port of the prepare service")
@@ -81,7 +83,6 @@ var (
 	queryServiceUseTLS       = flag.Bool("query-service-use-tls", false, "should TLS be used to connect to the query service")
 	restPort                 = flag.Int("rest-port", 3365, "the port of the REST listener")
 	safeShutdownSeconds      = flag.Int("safe-shutdown-seconds", 120, "the maximum duration in seconds to try to perform a safe shutdown before killing in-flight requests")
-	serviceName              = flag.String("service-name", "api", "the name of this service")
 
 	license = flag.Bool("license", false, "prints the software's license")
 	version = flag.Bool("version", false, "prints the software's version")
@@ -128,8 +129,6 @@ func main() {
 		return
 	}
 
-	log.Info().Msgf("Starting %s...", *serviceName)
-
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -138,13 +137,16 @@ func main() {
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(interrupt)
 
-	logProvider := telemetry.NewLoggingProvider(*debug, *debugGrpc, *logFormatJson, *logHealthCheck, *env)
+	noColor := *logNoColor == 1
+	logProvider := telemetry.NewLoggingProvider(*debug, *debugGrpc, *logFormatJson, *logHealthCheck, noColor, *env)
 	metricsProvider := telemetry.NewMetricsProvider()
 
 	traceProvider, shutdownTrace := telemetry.NewTracingProvider(ctx, *otelEndpoint)
 	defer shutdownTrace()
 
 	g, ctx := errgroup.WithContext(ctx)
+
+	log.Info().Msg("starting manager")
 
 	// setup compute clients
 	if *fileServiceHost != "" {
@@ -173,7 +175,7 @@ func main() {
 
 	entConfig := client.NewEntConfig(*dbDialect, dbName, dbHost, dbInMemory, dbPath, dbPass, dbPort, dbUser, dbUseSSL)
 	entClient := client.NewEntClient(ctx, entConfig)
-	if *debug {
+	if *debugDB {
 		entClient = entClient.Debug()
 	}
 	defer entClient.Close()
@@ -305,7 +307,7 @@ func main() {
 
 		log.Info().Int("grpcPort", *grpcPort).Msg("gRPC server is online")
 
-		healthServer.SetServingStatus(fmt.Sprintf("grpc.health.v1.%s", *serviceName), healthpb.HealthCheckResponse_SERVING)
+		healthServer.SetServingStatus("grpc.health.v1.manager", healthpb.HealthCheckResponse_SERVING)
 
 		return grpcServer.Serve(lis)
 	})
@@ -360,7 +362,7 @@ func main() {
 	cancel()
 	log.Info().Msg("canceled the main context")
 
-	healthServer.SetServingStatus(fmt.Sprintf("grpc.health.v1.%s", *serviceName), healthpb.HealthCheckResponse_NOT_SERVING)
+	healthServer.SetServingStatus("grpc.health.v1.manager", healthpb.HealthCheckResponse_NOT_SERVING)
 	log.Info().Msg("set gRPC-health status to not-serving")
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Duration(*safeShutdownSeconds)*time.Second)
@@ -373,7 +375,7 @@ func main() {
 	gracefulStopGrpcServer(grpcHealthServer, "gRPC-health")
 
 	if err := g.Wait(); err != nil {
-		log.Fatal().Err(err).Msgf("%s terminated!", *serviceName)
+		log.Fatal().Err(err).Msg("manager terminated!")
 	}
 }
 


### PR DESCRIPTION
Added flags and `NO_COLOR` environment variable support to both wren & sparrow to disable ANSI color args in log output when set.

see: https://no-color.org/

Also 
* Disabled wren logging database calls by default in debug mode.  Added new flag to re-enable when desired.
* Updated python client to disable color log output for services


