### PR TITLE
Fenl Diagnostic HTML Rendering (#280)

### DIFF
--- a/clients/python/src/kaskada/errors/error_codes.py
+++ b/clients/python/src/kaskada/errors/error_codes.py
@@ -1,0 +1,52 @@
+from typing import Dict
+
+from domonic.html import a
+
+KASKADA_DOC_ENDPOINT = "https://kaskada.io/docs-site/kaskada/main"
+
+
+class KaskadaDocLink:
+    """Encapsulates a Kaskada Document Link"""
+
+    def __init__(self, path: str):
+        """Instantiates a Kaskada Document Link
+
+        Args:
+            path (str): the path to append to KASKADA_DOC_ENDPOINT
+        """
+        self.path = path
+
+    def get_qualified_url(self) -> str:
+        """Gets the fully qualified URL for the document link.
+
+        Returns:
+            str: the fully qualified URL (endpoint + path)
+        """
+        return f"{KASKADA_DOC_ENDPOINT}{self.path}"
+
+
+class FenlDiagnosticError:
+    """Represents a Fenl Diagnostic Error"""
+
+    def __init__(self, code: str, doc_path: str):
+        """Instantiates a Fenl Diagnostic Error
+
+        Args:
+            code (str): The error code from the Engine e.g. E0010
+            doc_path (str): The doc path for more information
+        """
+        self.code = code
+        self.link = KaskadaDocLink(doc_path)
+
+    def render_error_code(self) -> str:
+        """Renders the error code as a string as <a href="<fully qualifed url>" target="_blank">code</a>
+
+        Returns:
+            str: the string a html element
+        """
+        return str(a(self.code, _href=self.link.get_qualified_url(), _target="_blank"))
+
+
+E0013 = FenlDiagnosticError("E0013", "/fenl/fenl-diagnostic-codes.html#E0013")
+
+FENL_DIAGNOSTIC_ERRORS: Dict[str, FenlDiagnosticError] = {"E0013": E0013}

--- a/clients/python/tests/errors/test_error_codes.py
+++ b/clients/python/tests/errors/test_error_codes.py
@@ -1,0 +1,20 @@
+import kaskada.errors.error_codes as error_codes
+
+
+def test_kaskada_doc_link():
+    expected_qualified_url = (
+        "https://kaskada.io/docs-site/kaskada/main/awkward/tacos/1234#rapid-turles"
+    )
+    kaskada_doc = error_codes.KaskadaDocLink("/awkward/tacos/1234#rapid-turles")
+    assert expected_qualified_url == kaskada_doc.get_qualified_url()
+
+
+def test_fenl_diagnostic_error():
+    error_code = "E1234"
+    doc_path = "/awkward/tacos/1234#rapid-turles"
+    diagnostic_error = error_codes.FenlDiagnosticError(error_code, doc_path)
+    result = diagnostic_error.render_error_code()
+    assert (
+        result
+        == '<a href="https://kaskada.io/docs-site/kaskada/main/awkward/tacos/1234#rapid-turles" target="_blank">E1234</a>'
+    )

--- a/clients/python/tests/test_formatters_shared.py
+++ b/clients/python/tests/test_formatters_shared.py
@@ -155,3 +155,14 @@ def test_table_html_pulsar_table():
     )
     assert schema is None
     assert str(render) == str(expected)
+
+
+def test_update_diagnostic_with_link():
+    valid_error = (
+        "error[E0013]: Invalid output type = Output type must be a record, but was i64"
+    )
+    result = formatters.update_diagnostic_with_link(valid_error)
+    assert (
+        result
+        == 'error[<a href="https://kaskada.io/docs-site/kaskada/main/fenl/fenl-diagnostic-codes.html#E0013" target="_blank">E0013</a>]: Invalid output type = Output type must be a record, but was i64'
+    )

--- a/docs-src/modules/fenl/nav.adoc
+++ b/docs-src/modules/fenl/nav.adoc
@@ -9,3 +9,4 @@
 ** xref:catalog.adoc[] 
 ** xref:fenl-faq.adoc[]
 ** xref:working-with-records.adoc[]
+** xref:fenl-diagnostic-codes.adoc[]

--- a/docs-src/modules/fenl/pages/fenl-diagnostic-codes.adoc
+++ b/docs-src/modules/fenl/pages/fenl-diagnostic-codes.adoc
@@ -1,0 +1,10 @@
+= Fenl Diagnostic Error Codes
+
+== E0013
+
+`error[E0013]: Invalid output type = Output type must be a record, but was X`
+
+The values produced by all Fenl expressions must be a record. 
+A record is a representation of multiple data types into a single value.
+This error indicates that the offending query produces a non-record type.
+To fix this, update the query to return a record type. For more information, see https://docs.kaskada.com/docs/data-model#records[Records]


### PR DESCRIPTION
# Fenl Diagnostic HTML Rendering 

Updates the rendering of the Fenl Diagnostic to render HTML A tags for known and documented error. Also lays out the ground work for easy error documentation.

The new implementation will scan through a Fenl Diagnostic for an error code using the regex `error\[(,?.*)\]`, then check to see if that code is documented as part of the `error_codes.py: FENL_DIAGNOSTIC_ERRORS`. If there is a documented error, the code converts the error code to an HTML <a> link.

**Example of a pre-defined error:** (Note the hyperlink E0013)
<img width="542" alt="Screenshot 2023-05-23 at 9 34 48 PM" src="https://github.com/kaskada-ai/kaskada/assets/15032894/052516fb-fa6f-4efd-b81c-857fa11a40de">

**Example of the default undocumented case:**
<img width="727" alt="Screenshot 2023-05-23 at 9 35 20 PM" src="https://github.com/kaskada-ai/kaskada/assets/15032894/ec3996da-8919-467a-b4d7-b2a76440a31d">
