### PR TITLE
(test) fix pip package test to avoid infinite restart

### DIFF
--- a/tests/integration/pythonClient/test_package.py
+++ b/tests/integration/pythonClient/test_package.py
@@ -13,4 +13,11 @@ except:
     sys.exit(1)
 
 print("**** SUCCESS! I can create a Kaskada Session.")
+try: 
+    session.stop()
+    print ("**** SUCCESS! I can stop a Kaskada Session.")
+except: 
+    traceback.print_exc()
+    sys.exit(0) # grpc _channel fails for some reason on stop, but it's not a big deal 
+    
 sys.exit(0)


### PR DESCRIPTION
Added feature to restart manager and engine causes original script to go in an infinite restart loop. Testing the pip package now calls `session.stop()` to terminate the session 

*NOTE*: there is an error from grpc and _channel.py that we ignore, our processes seem to be terminated correctly 