### PR TITLE
feat: introduce pipeline scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4599,6 +4599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sparrow-backend"
+version = "0.7.0"
+dependencies = [
+ "arrow-schema",
+ "sparrow-core",
+ "sparrow-physical",
+]
+
+[[package]]
 name = "sparrow-catalog"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,6 +2565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "index_vec"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74086667896a940438f2118212f313abba4aff3831fef6f4b17d02add5c8bb60"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4603,6 +4612,7 @@ name = "sparrow-backend"
 version = "0.7.0"
 dependencies = [
  "arrow-schema",
+ "index_vec",
  "sparrow-core",
  "sparrow-physical",
 ]
@@ -4836,6 +4846,7 @@ dependencies = [
  "arrow-schema",
  "bigdecimal",
  "enum-as-inner",
+ "index_vec",
  "insta",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ futures-lite = "1.12.0"
 half = { version = "2.2.1", features = ["serde"] }
 hashbrown = { version = "0.13.2", features = ["serde"] }
 hex = "0.4.3"
+index_vec = { version = "0.1.3", features = ["serde"] }
 indoc = "1.0.9"
 insta = { version = "1.29.0", features = ["ron", "yaml", "json"] }
 inventory = "0.3.5"

--- a/crates/sparrow-backend/Cargo.toml
+++ b/crates/sparrow-backend/Cargo.toml
@@ -11,6 +11,7 @@ Compilation backend for Kaskada queries.
 
 [dependencies]
 arrow-schema.workspace = true
+index_vec.workspace = true
 sparrow-core = { path = "../sparrow-core" }
 sparrow-physical = { path = "../sparrow-physical" }
 

--- a/crates/sparrow-backend/Cargo.toml
+++ b/crates/sparrow-backend/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sparrow-backend"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+description = """
+Compilation backend for Kaskada queries.
+"""
+
+[dependencies]
+arrow-schema.workspace = true
+sparrow-core = { path = "../sparrow-core" }
+sparrow-physical = { path = "../sparrow-physical" }
+
+[dev-dependencies]
+
+[lib]
+doctest = false

--- a/crates/sparrow-backend/src/lib.rs
+++ b/crates/sparrow-backend/src/lib.rs
@@ -1,0 +1,19 @@
+#![warn(
+    rust_2018_idioms,
+    nonstandard_style,
+    future_incompatible,
+    clippy::mod_module_files,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::undocumented_unsafe_blocks
+)]
+
+//! Compiler backend for Kaskada queries.
+//!
+//! The backend is responsible for converting logical plans to physical plans.
+//! It also performs optimizations on both the logical plans and the physical
+//! plans.
+
+mod pipeline_schedule;
+
+pub use pipeline_schedule::*;

--- a/crates/sparrow-backend/src/pipeline_schedule.rs
+++ b/crates/sparrow-backend/src/pipeline_schedule.rs
@@ -29,8 +29,7 @@ pub fn pipeline_schedule(steps: &IndexSlice<StepId, [Step]>) -> Vec<Pipeline> {
 
     let mut pipelines = Vec::new();
     for (index, step) in steps.iter_enumerated() {
-        let index: StepId = index.into();
-        let assignment = if is_pipeline_breaker(index, &step, &references) {
+        let assignment = if is_pipeline_breaker(index, step, &references) {
             // A step with no input (such as a scan) starts a new pipeline.
             // A step with multiple inputs (such as a merge) is a separate pipeline.
             let index = pipelines.len();

--- a/crates/sparrow-backend/src/pipeline_schedule.rs
+++ b/crates/sparrow-backend/src/pipeline_schedule.rs
@@ -1,0 +1,163 @@
+use sparrow_core::debug_println;
+use sparrow_physical::{Pipeline, Step, StepKind};
+
+const DEBUG_SCHEDULING: bool = false;
+
+/// Determine the pipeline each step should be part of.
+///
+/// This is computed in a bottom-up manner:
+///
+/// 1. Each leaf (input) is the start of a separate pipeline.
+/// 2. Certain step kinds are "pipeline breaking", which means
+///    they start a new pipeline. For instance, `with_key`.
+/// 3. Any other operation with a single input is part of the
+///    the same pipeline as the input.
+/// 4. Any other operation is a separate pipeline.
+pub fn pipeline_schedule(steps: &[Step]) -> Vec<Pipeline> {
+    // Compute how many times each step is referenced.
+    // Any step referenced multiple times must end a pipeline.
+    let mut references = vec![0; steps.len()];
+    for step in steps {
+        for input in &step.inputs {
+            references[input.0] += 1;
+        }
+    }
+
+    // Then compute the assignments for each step.
+    let mut assignments = Vec::with_capacity(steps.len());
+
+    let mut pipelines = Vec::new();
+    for (index, step) in steps.iter().enumerate() {
+        let break_pipeline = if step.inputs.len() != 1 {
+            debug_println!(
+                DEBUG_SCHEDULING,
+                "Step {index} is new pipeline since it has multiple inputs"
+            );
+            true
+        } else if references[step.inputs[0].0] > 1 {
+            debug_println!(
+                DEBUG_SCHEDULING,
+                "Step {index} is new pipeline since it's only input ({}) is referenced {} times",
+                step.inputs[0].0,
+                references[step.inputs[0].0]
+            );
+            true
+        } else if is_pipeline_breaker(&step.kind) {
+            debug_println!(
+                DEBUG_SCHEDULING,
+                "Step {index} is new pipeline based on kind {:?}",
+                step.kind
+            );
+            true
+        } else {
+            false
+        };
+
+        let assignment = if break_pipeline {
+            // A step with no input (such as a scan) starts a new pipeline.
+            // A step with multiple inputs (such as a merge) is a separate pipeline.
+            let index = pipelines.len();
+            pipelines.push(Pipeline::default());
+            index
+        } else {
+            // The step has exactly 1 input and is not a pipeline breaker.
+            assignments[step.inputs[0].0]
+        };
+
+        // Add this step to the assigned pipeline and record the assignment.
+        pipelines[assignment].steps.push(index.into());
+        assignments.push(assignment);
+    }
+
+    pipelines
+}
+
+/// Return true if the step is "pipeline breaking".
+fn is_pipeline_breaker(kind: &StepKind) -> bool {
+    matches!(
+        kind,
+        StepKind::Scan { .. } | StepKind::Merge | StepKind::Repartition { .. }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_schema::Schema;
+    use sparrow_physical::{Exprs, Pipeline, Step, StepKind};
+
+    use crate::pipeline_schedule;
+
+    #[test]
+    fn test_schedule_pipeline() {
+        let schema = Arc::new(Schema::empty());
+        let steps = vec![
+            // 0: scan table1
+            Step {
+                kind: StepKind::Scan {
+                    table_name: "table1".to_owned(),
+                },
+                inputs: vec![],
+                schema: schema.clone(),
+            },
+            // 1: scan table2
+            Step {
+                kind: StepKind::Scan {
+                    table_name: "table2".to_owned(),
+                },
+                inputs: vec![],
+                schema: schema.clone(),
+            },
+            // 2: merge 0 and 1
+            Step {
+                kind: StepKind::Merge,
+                inputs: vec![0.into(), 1.into()],
+                schema: schema.clone(),
+            },
+            // 3: project 0 -> separate pipeline since 0 has 2 consumers
+            Step {
+                kind: StepKind::Project {
+                    exprs: Exprs::empty(),
+                },
+                inputs: vec![0.into()],
+                schema: schema.clone(),
+            },
+            // 4: project 2 -> same pipeline since only consumer
+            Step {
+                kind: StepKind::Project {
+                    exprs: Exprs::empty(),
+                },
+                inputs: vec![2.into()],
+                schema: schema.clone(),
+            },
+            // 5: merge 3 and 4 -> new pipeline since merge
+            Step {
+                kind: StepKind::Merge,
+                inputs: vec![3.into(), 4.into()],
+                schema: schema.clone(),
+            },
+        ];
+
+        assert_eq!(
+            pipeline_schedule(&steps),
+            vec![
+                Pipeline {
+                    steps: vec![0.into()]
+                },
+                Pipeline {
+                    steps: vec![1.into()]
+                },
+                Pipeline {
+                    steps: vec![2.into(), 4.into()]
+                },
+                Pipeline {
+                    steps: vec![3.into()]
+                },
+                Pipeline {
+                    steps: vec![5.into()]
+                }
+            ]
+        );
+    }
+}

--- a/crates/sparrow-physical/Cargo.toml
+++ b/crates/sparrow-physical/Cargo.toml
@@ -13,6 +13,7 @@ Physical execution plans for Kaskada queries.
 arrow-schema.workspace = true
 bigdecimal.workspace = true
 enum-as-inner.workspace = true
+index_vec.workspace = true
 serde.workspace = true
 
 [dev-dependencies]

--- a/crates/sparrow-physical/src/expr.rs
+++ b/crates/sparrow-physical/src/expr.rs
@@ -12,6 +12,13 @@ pub struct Exprs {
 }
 
 impl Exprs {
+    pub fn empty() -> Self {
+        Self {
+            exprs: vec![],
+            outputs: vec![],
+        }
+    }
+
     /// Create expressions computing the value of the last expression.
     pub fn singleton(exprs: Vec<Expr>) -> Self {
         let output = exprs.len() - 1;
@@ -19,6 +26,10 @@ impl Exprs {
             exprs,
             outputs: vec![output.into()],
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.outputs.is_empty()
     }
 
     pub fn is_singleton(&self) -> bool {

--- a/crates/sparrow-physical/src/expr.rs
+++ b/crates/sparrow-physical/src/expr.rs
@@ -3,6 +3,9 @@ use std::borrow::Cow;
 use arrow_schema::DataType;
 
 /// Represents 1 or more values computed by expressions.
+///
+/// Expressions are evaluated by producing a sequence of columns
+/// and then selecting specific columns from those computed.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Exprs {
     /// The expressions computing the intermediate values.

--- a/crates/sparrow-physical/src/expr.rs
+++ b/crates/sparrow-physical/src/expr.rs
@@ -1,6 +1,14 @@
 use std::borrow::Cow;
 
 use arrow_schema::DataType;
+use index_vec::IndexVec;
+
+index_vec::define_index_type! {
+    /// The identifier (index) of an expression.
+    pub struct ExprId = u32;
+
+    DISPLAY_FORMAT = "{}";
+}
 
 /// Represents 1 or more values computed by expressions.
 ///
@@ -9,7 +17,7 @@ use arrow_schema::DataType;
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Exprs {
     /// The expressions computing the intermediate values.
-    pub exprs: Vec<Expr>,
+    pub exprs: IndexVec<ExprId, Expr>,
     /// The indices of columns to output.
     pub outputs: Vec<ExprId>,
 }
@@ -17,7 +25,7 @@ pub struct Exprs {
 impl Exprs {
     pub fn empty() -> Self {
         Self {
-            exprs: vec![],
+            exprs: IndexVec::default(),
             outputs: vec![],
         }
     }
@@ -26,7 +34,7 @@ impl Exprs {
     pub fn singleton(exprs: Vec<Expr>) -> Self {
         let output = exprs.len() - 1;
         Self {
-            exprs,
+            exprs: exprs.into(),
             outputs: vec![output.into()],
         }
     }
@@ -42,18 +50,6 @@ impl Exprs {
     /// Return the number of outputs produced by these expressions.
     pub fn output_len(&self) -> usize {
         self.outputs.len()
-    }
-}
-
-/// The identifier (index) of an expression.
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-#[serde(transparent)]
-pub struct ExprId(usize);
-
-impl From<usize> for ExprId {
-    fn from(value: usize) -> Self {
-        ExprId(value)
     }
 }
 

--- a/crates/sparrow-physical/src/plan.rs
+++ b/crates/sparrow-physical/src/plan.rs
@@ -1,4 +1,4 @@
-use crate::Step;
+use crate::{Step, StepId};
 
 /// A plan is a directed, acyclic graph of steps.
 ///
@@ -9,4 +9,19 @@ use crate::Step;
 pub struct Plan {
     /// The steps in the plan.
     pub steps: Vec<Step>,
+    /// The pipelines within the plan.
+    pub pipelines: Vec<Pipeline>,
+}
+
+/// Information about a specific "pipeline" within the plan.
+///
+/// Pipelines take a single input through a linear sequence of
+/// steps. Identifying pipelines within the plan provides units
+/// of work that ideally run on the same core.
+///
+/// See [Morsel-driven Parallelism](https://dl.acm.org/doi/10.1145/2588555.2610507).
+#[derive(Debug, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+pub struct Pipeline {
+    /// The steps that are part of this pipeline.
+    pub steps: Vec<StepId>,
 }

--- a/crates/sparrow-physical/src/plan.rs
+++ b/crates/sparrow-physical/src/plan.rs
@@ -1,3 +1,5 @@
+use index_vec::IndexVec;
+
 use crate::{Step, StepId};
 
 /// A plan is a directed, acyclic graph of steps.
@@ -8,7 +10,7 @@ use crate::{Step, StepId};
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Plan {
     /// The steps in the plan.
-    pub steps: Vec<Step>,
+    pub steps: IndexVec<StepId, Step>,
     /// The pipelines within the plan.
     pub pipelines: Vec<Pipeline>,
 }

--- a/crates/sparrow-physical/src/step.rs
+++ b/crates/sparrow-physical/src/step.rs
@@ -2,17 +2,11 @@ use arrow_schema::SchemaRef;
 
 use crate::Exprs;
 
-/// The identifier (index) of a step.
+index_vec::define_index_type! {
+    /// The identifier (index) of a step.
+    pub struct StepId = u32;
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-#[serde(transparent)]
-pub struct StepId(pub usize);
-
-impl From<usize> for StepId {
-    fn from(value: usize) -> Self {
-        StepId(value)
-    }
+    DISPLAY_FORMAT = "{}";
 }
 
 /// A single step in the physical plan.

--- a/crates/sparrow-physical/src/step.rs
+++ b/crates/sparrow-physical/src/step.rs
@@ -16,6 +16,20 @@ impl From<usize> for StepId {
 }
 
 /// A single step in the physical plan.
+///
+/// Each step corresponds to a specific relational operator.
+/// Many [kinds of steps](StepKind) include [expressions](Exprs)
+/// to specify columns -- for instance the columns to compute in
+/// a projection or the condition to use for a selection.
+/// Conceptually, steps describe how batches are produced while
+/// expressions describe columns inside a batch.
+///
+/// During execution, each step receives an partitioned stream
+/// of ordered batches and produces a partitioned stream of
+/// ordered batches. Steps never operate between partitions --
+/// instead, operations like `with_key` for a given partition
+/// produce output to destined for multiple partitions based
+/// on the newly computed keys.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Step {
     /// The kind of step being performed.

--- a/crates/sparrow-physical/src/step.rs
+++ b/crates/sparrow-physical/src/step.rs
@@ -7,7 +7,7 @@ use crate::Exprs;
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 #[serde(transparent)]
-pub struct StepId(usize);
+pub struct StepId(pub usize);
 
 impl From<usize> for StepId {
     fn from(value: usize) -> Self {
@@ -18,7 +18,6 @@ impl From<usize> for StepId {
 /// A single step in the physical plan.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Step {
-    pub id: StepId,
     /// The kind of step being performed.
     pub kind: StepKind,
     /// Inputs to this step.

--- a/crates/sparrow-physical/src/step.rs
+++ b/crates/sparrow-physical/src/step.rs
@@ -18,11 +18,11 @@ index_vec::define_index_type! {
 /// Conceptually, steps describe how batches are produced while
 /// expressions describe columns inside a batch.
 ///
-/// During execution, each step receives an partitioned stream
+/// During execution, each step receives a partitioned stream
 /// of ordered batches and produces a partitioned stream of
 /// ordered batches. Steps never operate between partitions --
 /// instead, operations like `with_key` for a given partition
-/// produce output to destined for multiple partitions based
+/// produce output destined for multiple partitions based
 /// on the newly computed keys.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Step {


### PR DESCRIPTION
This is part of #409.

Introduces `Pipeline` information to the physical plan. This indicates which steps are part of a linear sequence, and should (ideally) be executed together.

Also implements a pipeline "scheduler" to determine the pipeline for each step, in a new `sparrow-backend` crate. As the physical plan is built-up, the code should go in this "compiler backend" package, which can own optimization and conversion of logical plans to physical plans.