### PR TITLE
feat: remove ack from pulsar reader

### DIFF
--- a/crates/sparrow-runtime/src/streams/pulsar/stream.rs
+++ b/crates/sparrow-runtime/src/streams/pulsar/stream.rs
@@ -196,13 +196,13 @@ impl PulsarReader {
 
             match msg {
                 Some(msg) => {
-                    // Note: Intentionally not acking here. 
-                    // In the materialization case, we should be using subscriptions to start from 
-                    // a specific offset. We do not want to ack messages in case we need to re-read 
-                    // messages from a time in the past to handle late data or backfills. 
+                    // Note: Intentionally not acking here.
+                    // In the materialization case, we should be using subscriptions to start from
+                    // a specific offset. We do not want to ack messages in case we need to re-read
+                    // messages from a time in the past to handle late data or backfills.
                     //
-                    // TODO: It's possible this breaks the specialized prepare demo - 
-                    // `prepare` may duplicate input data into the same spot. 
+                    // TODO: It's possible this breaks the specialized prepare demo -
+                    // `prepare` may duplicate input data into the same spot.
 
                     let result: error_stack::Result<AvroWrapper, DeserializeError> =
                         msg.deserialize();

--- a/crates/sparrow-runtime/src/streams/pulsar/stream.rs
+++ b/crates/sparrow-runtime/src/streams/pulsar/stream.rs
@@ -196,10 +196,14 @@ impl PulsarReader {
 
             match msg {
                 Some(msg) => {
-                    self.consumer
-                        .ack(&msg)
-                        .await
-                        .map_err(|e| ArrowError::from_external_error(Box::new(e)))?;
+                    // Note: Intentionally not acking here. 
+                    // In the materialization case, we should be using subscriptions to start from 
+                    // a specific offset. We do not want to ack messages in case we need to re-read 
+                    // messages from a time in the past to handle late data or backfills. 
+                    //
+                    // TODO: It's possible this breaks the specialized prepare demo - 
+                    // `prepare` may duplicate input data into the same spot. 
+
                     let result: error_stack::Result<AvroWrapper, DeserializeError> =
                         msg.deserialize();
                     let aw = match result {


### PR DESCRIPTION
This removes the `ack` when reading messages from pulsar. The reason being that if we run a query twice, we want it to run over the same data in the stream instead of consuming the data. 

For materializations, we should rely on the subscription and broker to decide the offset at which to start reading (once we start saving state). Otherwise, each materialization should start at the beginning of the stream and produce deterministic results. Of course, this does depend on the configured lifetime of events in the stream, but that is expected. 

However, there is a small chance this breaks the pulsar demo that worked by preparing messages into parquet files then querying over those - since we're not acking, if we try to prepare multiple times, I wonder if we would be duplicated input data into the prepared files. But, unlikely this demo is used anymore, and we most likely want to phase this code path out anyway in favor of reading directly from the stream. Preparing streams to files has its place, but there's more work involved there regardless to have that a user-ready feature.  