### PR TITLE
docs(getting-started): update queries

### DIFF
--- a/docs-src/modules/getting-started/examples/filter-patrick.fenl
+++ b/docs-src/modules/getting-started/examples/filter-patrick.fenl
@@ -1,0 +1,1 @@
+Purchase | when(Purchase.customer_id == "patrick")

--- a/docs-src/modules/getting-started/examples/purchase.fenl
+++ b/docs-src/modules/getting-started/examples/purchase.fenl
@@ -1,0 +1,1 @@
+Purchase

--- a/docs-src/modules/getting-started/examples/unique-code.fenl
+++ b/docs-src/modules/getting-started/examples/unique-code.fenl
@@ -1,0 +1,18 @@
+# How many big purchases happen each hour and where?
+# Anything can be named and re-used
+let hourly_big_purchases = Purchase
+| when(Purchase.amount > 10)
+
+# Filter anywhere
+| count(window=since(hourly()))
+
+# Aggregate anything
+| when(hourly())
+
+# Shift timelines relative to each other
+let purchases_now = count(Purchase)
+let purchases_yesterday =
+   purchases_now | shift_by(days(1))
+
+# Records are just another type
+in { hourly_big_purchases, purchases_in_last_day: purchases_now - purchases_yesterday }

--- a/docs-src/modules/getting-started/pages/hello-world-cli.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-cli.adoc
@@ -200,11 +200,9 @@ Data loaded into Kaskada is accessed by performing Fenl Queries.
 Let's start by looking at the Purchase table without any filters.
 Begin by creating a text file with the following query:
 
-[source,Fenl]
 .query.fenl
-----
-Purchase
-----
+include::partial$cli-purchase.adoc[]
+ 
 
 This query will return all of the columns and rows contained in a table.
 Run it by sending the query to `kaskada-cli query run`:
@@ -243,11 +241,8 @@ _time,_subsort,_key_hash,_key,id,purchase_time,customer_id,vendor_id,amount,subs
 It can be helpful to limit your results to a single entity.
 This makes it easier to see how a single entity changes over time.
 
-[source,Fenl]
 .query.fenl
-----
-Purchase | when(Purchase.customer_id == "patrick")
-----
+include::partial$cli-filter-patrick.adoc[]
 
 [source,bash]
 ----
@@ -282,34 +277,8 @@ We begin with the timeline produced by the table `Purchase`, then filter it to t
 Kaskada's query language provides a rich set of xref:fenl:catalog.adoc[operations] for reasoning about time.
 Here's a more sophisticated example that touches on many of the unique features of Kaskada queries:
 
-[source,Fenl]
 .query.fenl
-----
-# How many big purchases happen each hour and where?
-let cadence = hourly()
-
-# Anything can be named and re-used
-let hourly_big_purchases = Purchase
-| when(Purchase.amount > 10)
-
-# Filter anywhere
-| count(window=since(cadence))
-
-# Aggregate anything
-| when(cadence)
-
-# Shift timelines relative to each other
-let purchases_now = count(Purchase)
-let purchases_yesterday =
-   purchases_now | shift_by(days(1))
-
-# Records are just another type
-in { hourly_big_purchases, purchases_in_last_day: purchases_now - purchases_yesterday }
-| extend({
-  # …modify them sequentially
-  last_visit_region: last(Pageview.region)
-})
-----
+include::partial$cli-unique.adoc[]
 
 ****
 ⭢  Read more about writing queries in xref:developing:queries.adoc[]

--- a/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
+++ b/docs-src/modules/getting-started/pages/hello-world-jupyter.adoc
@@ -300,20 +300,14 @@ Let's start by looking at the `Purchase` table without any filters, this
 query will return all of the columns and rows contained in a table:
 
 [source,Fenl]
-----
-%%fenl
-Purchase
-----
+include::partial$nb-purchase.adoc[]
 
 This query will return all of the columns and rows contained in a table.
 It can be helpful to limit your results to a single entity.
 This makes it easier to see how a single entity changes over time.
 
 [source,Fenl]
-----
-%%fenl
-Purchase | when(Purchase.customer_id == "patrick")
-----
+include::partial$nb-filter-patrick.adoc[]
 
 In this example, we build a pipeline of functions using the `|` character.
 We begin with the timeline produced by the table `Purchase`, then filter it to the set of times where the purchase's customer is `"patrick"` using the `xref:fenl:catalog.adoc#when[when()]` function.
@@ -321,34 +315,7 @@ We begin with the timeline produced by the table `Purchase`, then filter it to t
 Kaskada's query language provides a rich set of operations for reasoning about time.
 Here's a more sophisticated example that touches on many of the unique features of Kaskada queries:
 
-[source,Fenl]
-----
-%%fenl
-# How many big purchases happen each hour and where?
-let cadence = hourly()
-
-# Anything can be named and re-used
-let hourly_big_purchases = Purchase
-| when(Purchase.amount > 10)
-
-# Filter anywhere
-| count(window=since(cadence))
-
-# Aggregate anything
-| when(cadence)
-
-# Shift timelines relative to each other
-let purchases_now = count(Purchase)
-let purchases_yesterday =
-   purchases_now | shift_by(days(1))
-
-# Records are just another type
-in { hourly_big_purchases, purchases_in_last_day: purchases_now - purchases_yesterday }
-| extend({
-  # …modify them sequentially
-  last_visit_region: last(Pageview.region)
-})
-----
+include::partial$nb-unique.adoc[]
 
 ****
 ⭢  Read more about writing queries in xref:developing:queries.adoc[]
@@ -369,22 +336,13 @@ When you make a query, the resulting timeline is interpreted in one of two ways:
 By default, timelines are output as histories.
 You can output a timeline as a snapshot by setting the `--result-behavior` fenlmagic argument to `final-results`.
 
-[source,Fenl]
-----
-%%fenl --result-behavior final-results
-Purchase | when(Purchase.customer_id == "patrick")
-----
+include::partial$nb-filter-patrick-final.adoc[]
 
 ==== Limiting how many rows are returned
 
 You can limit the number of rows returned from a query:
 
-[source,Fenl]
-----
-%%fenl --preview-rows 10
-Purchase | when(Purchase.customer_id == "patrick")
-----
-
+include::partial$nb-filter-patrick-preview-rows.adoc[]
 [TIP]
 ====
 This may return more rows that you asked for.
@@ -396,11 +354,7 @@ When you configure `--preview-rows` Kaskada stops processing at the end of a bat
 
 To capture the result of a query and assign it to the variable `query_result`:
 
-[source,Fenl]
-----
-%%fenl --var query_result
-Purchase | when(Purchase.customer_id == "patrick")
-----
+include::partial$nb-filter-patrick-var.adoc[]
 
 You can now inspect the resulting dataframe, or the original query string:
 

--- a/docs-src/modules/getting-started/partials/cli-filter-patrick.adoc
+++ b/docs-src/modules/getting-started/partials/cli-filter-patrick.adoc
@@ -1,0 +1,4 @@
+[source,Fenl]
+----
+include::example$filter-patrick.fenl[]
+----

--- a/docs-src/modules/getting-started/partials/cli-purchase.adoc
+++ b/docs-src/modules/getting-started/partials/cli-purchase.adoc
@@ -1,0 +1,4 @@
+[source,fenl]
+----
+include::example$purchase.fenl[]
+----

--- a/docs-src/modules/getting-started/partials/cli-unique.adoc
+++ b/docs-src/modules/getting-started/partials/cli-unique.adoc
@@ -1,0 +1,5 @@
+
+[source,Fenl]
+----
+include::example$unique-code.fenl[]
+----

--- a/docs-src/modules/getting-started/partials/nb-filter-patrick-final.adoc
+++ b/docs-src/modules/getting-started/partials/nb-filter-patrick-final.adoc
@@ -1,0 +1,5 @@
+[source,Fenl]
+----
+%%fenl --result-behavior final-results
+Purchase | when(Purchase.customer_id == "patrick")
+----

--- a/docs-src/modules/getting-started/partials/nb-filter-patrick-preview-rows.adoc
+++ b/docs-src/modules/getting-started/partials/nb-filter-patrick-preview-rows.adoc
@@ -1,0 +1,5 @@
+[source,Fenl]
+----
+%%fenl --preview-rows 10
+Purchase | when(Purchase.customer_id == "patrick")
+----

--- a/docs-src/modules/getting-started/partials/nb-filter-patrick-var.adoc
+++ b/docs-src/modules/getting-started/partials/nb-filter-patrick-var.adoc
@@ -1,0 +1,5 @@
+[source,Fenl]
+----
+%%fenl --var query_result
+Purchase | when(Purchase.customer_id == "patrick")
+----

--- a/docs-src/modules/getting-started/partials/nb-filter-patrick.adoc
+++ b/docs-src/modules/getting-started/partials/nb-filter-patrick.adoc
@@ -1,0 +1,5 @@
+[source,Fenl]
+----
+%%fenl
+include::example$filter-patrick.fenl[]
+----

--- a/docs-src/modules/getting-started/partials/nb-purchase.adoc
+++ b/docs-src/modules/getting-started/partials/nb-purchase.adoc
@@ -1,0 +1,5 @@
+[source,fenl]
+----
+%%fenl
+include::example$purchase.fenl[]
+----

--- a/docs-src/modules/getting-started/partials/nb-unique.adoc
+++ b/docs-src/modules/getting-started/partials/nb-unique.adoc
@@ -1,0 +1,6 @@
+
+[source,Fenl]
+----
+%%fenl
+include::example$unique-code.fenl[]
+----


### PR DESCRIPTION
* moves code in `examples`
* creates partial pages for fenl code that is reused for cli and notebook 
    * we need to wrap the fenl code in order to add `%%fenl` for notebooks (files prefixed with `nb`) and without `%%fenl` for cli (files prefixed with `cli`)
* updated the more complex query to 
    1. Remove the queries dependency on `PageViews` table since we do not provide data for that table (see #411) 
    2. Deal with a bug (will file separate issue) when binding `hourly()` to a name `cadence`
    