### PR TITLE
Update Pulsar Output Per Batch

### DIFF
--- a/crates/sparrow-runtime/src/execute/output/pulsar.rs
+++ b/crates/sparrow-runtime/src/execute/output/pulsar.rs
@@ -147,6 +147,18 @@ pub(super) async fn write(
                 .into_report()
                 .change_context(Error::SendingMessage)?;
         }
+        // Send the buffer in the producer, if one exists.
+        //
+        // After every batch, the size of the batch may be less than the configured BATCH_SIZE.
+        // The current Pulsar client will wait until the batch reaches the BATCH_SIZE, this explicitly
+        // sends the current batch to avoid waiting indefinitely until BATCH_SIZE is achieved.
+        //
+        // This is not optimal and may raise performance concerns to send small batches.
+        producer.send_batch()
+            .await
+            .into_report()
+            .change_context(Error::SendingMessage)?;
+
         tracing::debug!("Success. Buffered {num_rows} messages to pulsar");
 
         progress_updates_tx
@@ -155,17 +167,6 @@ pub(super) async fn write(
             .into_report()
             .change_context(Error::ProgressUpdate)?;
     }
-
-    // Send the buffer in the producer, if one exists.
-    //
-    // Ideally, this is done automatically by the producer, but in the absense
-    // of a `maxPublishDelay` or similar clean-up process that flushes batches,
-    // we need to explicitly send the final batch.
-    producer
-        .send_batch()
-        .await
-        .into_report()
-        .change_context(Error::SendingMessage)?;
 
     Ok(())
 }

--- a/crates/sparrow-runtime/src/execute/output/pulsar.rs
+++ b/crates/sparrow-runtime/src/execute/output/pulsar.rs
@@ -154,7 +154,8 @@ pub(super) async fn write(
         // sends the current batch to avoid waiting indefinitely until BATCH_SIZE is achieved.
         //
         // This is not optimal and may raise performance concerns to send small batches.
-        producer.send_batch()
+        producer
+            .send_batch()
             .await
             .into_report()
             .change_context(Error::SendingMessage)?;

--- a/crates/sparrow-runtime/src/streams/pulsar/stream.rs
+++ b/crates/sparrow-runtime/src/streams/pulsar/stream.rs
@@ -281,7 +281,6 @@ impl PulsarReader {
                     ArrowError::from_external_error(Box::new(e))
                 })?;
                 let batch = RecordBatch::try_new(self.raw_schema.clone(), arrow_data)?;
-
                 // Note that the _publish_time is dropped here. This field is added for the purposes of
                 // prepare, where the `time` column is automatically set to the `_publish_time`.
                 let columns_to_read = get_columns_to_read(&self.raw_schema, &self.projected_schema);

--- a/tests/integration/api/mat_pulsar_to_pulsar_test.go
+++ b/tests/integration/api/mat_pulsar_to_pulsar_test.go
@@ -26,7 +26,7 @@ type pulsarToPulsarTestSchema struct {
 	Count    int `json:"count"`
 }
 
-var _ = FDescribe("Materialization from Pulsar to Pulsar", Ordered, Label("pulsar"), func() {
+var _ = PDescribe("Materialization from Pulsar to Pulsar", Ordered, Label("pulsar"), func() {
 	var (
 		ctx                   context.Context
 		cancel                context.CancelFunc


### PR DESCRIPTION
Updates the pulsar output module to have the producer send the internal batch after processing every batch. See: https://docs.google.com/document/d/1gU8NV65ATliGd2-eG2G-mCX2mu8S3jY9m9x1wOVqsaw/edit?usp=sharing (June 22, 2023) for more info.