### PR TITLE
bug: fix materialization stop signal 

### DIFF
--- a/crates/sparrow-materialize/src/materialize/materialization_control.rs
+++ b/crates/sparrow-materialize/src/materialize/materialization_control.rs
@@ -61,7 +61,7 @@ impl MaterializationControl {
                     }) {
                         Ok(_) => {}
                         Err(e) => {
-                            tracing::error!("failed to send progress to materialization: {}, stopping with error: {}", id.clone(), e);
+                            tracing::error!("failed to send progress for materialization: {}, stopping with error: {}", id.clone(), e);
                             break;
                         }
                     };
@@ -73,8 +73,12 @@ impl MaterializationControl {
                 progress: last_progress,
                 error: None,
             }) {
-                Ok(_) => {}
+                Ok(_) => {
+                    tracing::debug!("set materialization (id: {}) status to stopped", id.clone())
+                }
                 Err(e) => {
+                    // At this point, the query should be stopped (or stopping), but
+                    // we've failed to update the status.
                     tracing::error!(
                         "failed to set progress to stopped for materialization: {} with error: {}",
                         id.clone(),
@@ -83,7 +87,7 @@ impl MaterializationControl {
                 }
             }
 
-            tracing::error!("materialization {} exited unexpectedly", id);
+            tracing::info!("materialization (id: {}) is exiting", id);
             Ok(())
         });
 

--- a/crates/sparrow-runtime/src/execute.rs
+++ b/crates/sparrow-runtime/src/execute.rs
@@ -222,16 +222,13 @@ pub async fn execute(
         flight_record_path: None,
     };
 
-    // Note: This placeholder is used to support the [StopMaterialization] API, but can be easily used to
-    // support stopping a query in general.
-    let (_, stop_signal_rx) = tokio::sync::watch::channel(false);
     let compute_executor = ComputeExecutor::try_spawn(
         context,
         &late_bindings,
         &runtime_options,
         progress_updates_rx,
         destination,
-        stop_signal_rx,
+        None,
     )
     .await
     .change_context(Error::internal_msg("spawn compute executor"))?;
@@ -344,7 +341,7 @@ pub async fn materialize(
         &runtime_options,
         progress_updates_rx,
         destination,
-        stop_signal_rx,
+        Some(stop_signal_rx),
     )
     .await
     .change_context(Error::internal_msg("spawn compute executor"))?;

--- a/crates/sparrow-runtime/src/execute/compute_executor.rs
+++ b/crates/sparrow-runtime/src/execute/compute_executor.rs
@@ -54,7 +54,7 @@ impl ComputeExecutor {
         runtime_options: &RuntimeOptions,
         progress_updates_rx: tokio::sync::mpsc::Receiver<ProgressUpdate>,
         destination: v1alpha::Destination,
-        stop_signal_rx: tokio::sync::watch::Receiver<bool>,
+        stop_signal_rx: Option<tokio::sync::watch::Receiver<bool>>,
     ) -> error_stack::Result<Self, Error> {
         let mut spawner = ComputeTaskSpawner::new();
 

--- a/crates/sparrow-runtime/src/execute/operation.rs
+++ b/crates/sparrow-runtime/src/execute/operation.rs
@@ -170,7 +170,7 @@ impl OperationExecutor {
         input_channels: Vec<tokio::sync::mpsc::Receiver<Batch>>,
         max_event_time_tx: tokio::sync::mpsc::UnboundedSender<Timestamp>,
         late_bindings: &EnumMap<LateBoundValue, Option<ScalarValue>>,
-        stop_signal_rx: tokio::sync::watch::Receiver<bool>,
+        stop_signal_rx: Option<tokio::sync::watch::Receiver<bool>>,
     ) -> Result<impl Future<Output = Result<(), Error>>, Error> {
         let Self {
             operation,
@@ -383,7 +383,7 @@ async fn create_operation(
     operator: operation_plan::Operator,
     incoming_channels: Vec<tokio::sync::mpsc::Receiver<Batch>>,
     input_columns: &[InputColumn],
-    stop_signal_rx: tokio::sync::watch::Receiver<bool>,
+    stop_signal_rx: Option<tokio::sync::watch::Receiver<bool>>,
 ) -> Result<BoxedOperation, Error> {
     match operator {
         operation_plan::Operator::Scan(scan_operation) => {

--- a/crates/sparrow-runtime/src/execute/operation/scan.rs
+++ b/crates/sparrow-runtime/src/execute/operation/scan.rs
@@ -28,7 +28,7 @@ pub(super) struct ScanOperation {
     projected_schema: SchemaRef,
     /// The input stream of batches.
     ///
-    /// Takes until the stop signal is received
+    /// Takes until the stop signal is received or the stream is empty.
     input_stream: Pin<Box<dyn Stream<Item = error_stack::Result<Batch, Error>> + Send>>,
     key_hash_index: KeyHashIndex,
     progress_updates_tx: tokio::sync::mpsc::Sender<ProgressUpdate>,

--- a/crates/sparrow-runtime/src/execute/operation/scan.rs
+++ b/crates/sparrow-runtime/src/execute/operation/scan.rs
@@ -27,10 +27,11 @@ pub(super) struct ScanOperation {
     /// The schema of the scanned inputs.
     projected_schema: SchemaRef,
     /// The input stream of batches.
+    ///
+    /// Takes until the stop signal is received
     input_stream: Pin<Box<dyn Stream<Item = error_stack::Result<Batch, Error>> + Send>>,
     key_hash_index: KeyHashIndex,
     progress_updates_tx: tokio::sync::mpsc::Sender<ProgressUpdate>,
-    stop_signal_rx: tokio::sync::watch::Receiver<bool>,
 }
 
 impl std::fmt::Debug for ScanOperation {
@@ -61,14 +62,9 @@ impl Operation for ScanOperation {
         &mut self,
         sender: tokio::sync::mpsc::Sender<InputBatch>,
     ) -> error_stack::Result<(), Error> {
-        while let Some(incoming) = self
-            .input_stream
-            .try_next()
-            .await
-            .change_context(Error::GetNextInput)?
-        {
+        while let Some(batch) = self.input_stream.next().await {
             let input = self
-                .create_input(incoming)
+                .create_input(batch?)
                 .into_report()
                 .change_context(Error::PreprocessNextInput)?;
 
@@ -85,18 +81,11 @@ impl Operation for ScanOperation {
                 break;
             };
 
-            // Send batch.
             sender
                 .send(input)
                 .await
                 .into_report()
                 .change_context(Error::internal_msg("send next output"))?;
-
-            // Stops the operation if the signal is received.
-            if *self.stop_signal_rx.borrow() {
-                tracing::info!("Stop signal received. Ending scan");
-                break;
-            }
         }
 
         Ok(())
@@ -110,7 +99,7 @@ impl ScanOperation {
         scan_operation: operation_plan::ScanOperation,
         input_channels: Vec<tokio::sync::mpsc::Receiver<Batch>>,
         input_columns: &[InputColumn],
-        stop_signal_rx: tokio::sync::watch::Receiver<bool>,
+        mut stop_signal_rx: tokio::sync::watch::Receiver<bool>,
     ) -> error_stack::Result<BoxedOperation, Error> {
         error_stack::ensure!(
             input_channels.is_empty(),
@@ -233,16 +222,31 @@ impl ScanOperation {
                 .change_context(Error::internal_msg("failed to create stream reader"))?
                 .map_err(|e| e.change_context(Error::internal_msg("failed to read batch")))
                 .boxed();
+
                 input_stream
             }
         };
+
+        // Streams until the stop signal has been received
+        let input_stream = input_stream
+            .take_until(async move {
+                while !*stop_signal_rx.borrow() {
+                    match stop_signal_rx.changed().await {
+                        Ok(_) => (),
+                        Err(e) => {
+                            tracing::error!("Stop signal receiver dropped: {e}");
+                            break;
+                        }
+                    }
+                }
+            })
+            .boxed();
 
         Ok(Box::new(Self {
             projected_schema,
             input_stream,
             key_hash_index: KeyHashIndex::default(),
             progress_updates_tx: context.progress_updates_tx.clone(),
-            stop_signal_rx,
         }))
     }
 

--- a/crates/sparrow-runtime/src/execute/operation/scan.rs
+++ b/crates/sparrow-runtime/src/execute/operation/scan.rs
@@ -227,7 +227,9 @@ impl ScanOperation {
             }
         };
 
-        // Streams until the stop signal has been received
+        // Currently configures the stream for the following cases:
+        // 1) Streams until the stop signal is received or source is done producing (currently only used for materializations)
+        // 2) Streams until the source is done producing
         let input_stream = if let Some(mut stop_signal_rx) = stop_signal_rx {
             input_stream
                 .take_until(async move {

--- a/crates/sparrow-runtime/src/execute/operation/testing.rs
+++ b/crates/sparrow-runtime/src/execute/operation/testing.rs
@@ -174,7 +174,6 @@ pub(super) async fn run_operation(
     let s3_helper = S3Helper::new().await;
     // Channel for the output stats.
     let (progress_updates_tx, _) = tokio::sync::mpsc::channel(29);
-    let (_, stop_signal_rx) = tokio::sync::watch::channel(false);
 
     let key_hash_inverse = KeyHashInverse::from_data_type(DataType::Utf8);
     let key_hash_inverse = Arc::new(ThreadSafeKeyHashInverse::new(key_hash_inverse));
@@ -201,7 +200,7 @@ pub(super) async fn run_operation(
             inputs,
             max_event_tx,
             &Default::default(),
-            stop_signal_rx,
+            None,
         )
         .await
         .unwrap()
@@ -239,7 +238,6 @@ pub(super) async fn run_operation_json(
 
     // Channel for the output stats.
     let (progress_updates_tx, _) = tokio::sync::mpsc::channel(29);
-    let (_, stop_signal_rx) = tokio::sync::watch::channel(false);
     let mut context = OperationContext {
         plan: ComputePlan {
             operations: vec![plan],
@@ -262,7 +260,7 @@ pub(super) async fn run_operation_json(
             inputs,
             max_event_tx,
             &Default::default(),
-            stop_signal_rx,
+            None,
         )
         .await
         .unwrap()

--- a/crates/sparrow-runtime/src/execute/output/pulsar.rs
+++ b/crates/sparrow-runtime/src/execute/output/pulsar.rs
@@ -161,6 +161,11 @@ pub(super) async fn write(
             .change_context(Error::SendingMessage)?;
 
         tracing::debug!("Success. Buffered {num_rows} messages to pulsar");
+        producer
+            .send_batch()
+            .await
+            .into_report()
+            .change_context(Error::SendingMessage)?;
 
         progress_updates_tx
             .send(ProgressUpdate::Output { num_rows })

--- a/crates/sparrow-runtime/src/execute/output/pulsar.rs
+++ b/crates/sparrow-runtime/src/execute/output/pulsar.rs
@@ -154,12 +154,6 @@ pub(super) async fn write(
         // sends the current batch to avoid waiting indefinitely until BATCH_SIZE is achieved.
         //
         // This is not optimal and may raise performance concerns to send small batches.
-        producer
-            .send_batch()
-            .await
-            .into_report()
-            .change_context(Error::SendingMessage)?;
-
         tracing::debug!("Success. Buffered {num_rows} messages to pulsar");
         producer
             .send_batch()


### PR DESCRIPTION
Fixes the stop signal bug by using a stream in scan operation that takes until the signal is received. 

Still keeps the pulsar to pulsar tests ignored, since I have this log line I haven't figured out yet:
```
2023-06-26T14:20:32.562464Z ERROR Error sending end event to channel - send failed because receiver is gone    

```