### PR TITLE
ref: Move hashing to sparrow-arrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4545,9 +4545,11 @@ dependencies = [
 name = "sparrow-arrow"
 version = "0.8.3"
 dependencies = [
+ "ahash 0.8.3",
  "anyhow",
  "arrow",
  "arrow-array",
+ "arrow-buffer",
  "arrow-schema",
  "arrow-select",
  "avro-rs",
@@ -4556,6 +4558,7 @@ dependencies = [
  "decorum",
  "derive_more",
  "error-stack",
+ "half 2.2.1",
  "insta",
  "itertools",
  "num",
@@ -4725,7 +4728,6 @@ dependencies = [
 name = "sparrow-kernels"
 version = "0.8.3"
 dependencies = [
- "ahash 0.8.3",
  "anyhow",
  "arrow",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { version = "1.0.70", features = ["backtrace"] }
 approx = "0.5.1"
 arrow = { version = "42.0.0" }
 arrow-array = { version = "42.0.0" }
+arrow-buffer = { version = "42.0.0" }
 arrow-csv = { version = "42.0.0" }
 arrow-json = { version = "42.0.0" }
 arrow-schema = { version = "42.0.0", features = ["serde"] }

--- a/crates/sparrow-arrow/Cargo.toml
+++ b/crates/sparrow-arrow/Cargo.toml
@@ -16,9 +16,11 @@ testing = ["proptest"]
 
 # This crate should not depend on any other Sparrow crates.
 [dependencies]
+ahash.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
 arrow-array.workspace = true
+arrow-buffer.workspace = true
 arrow-schema.workspace = true
 arrow-select.workspace = true
 avro-schema = { workspace = true, optional = true }
@@ -27,6 +29,7 @@ chrono.workspace = true
 decorum.workspace = true
 derive_more.workspace = true
 error-stack.workspace = true
+half.workspace = true
 itertools.workspace = true
 num.workspace = true
 proptest = { workspace = true, optional = true }

--- a/crates/sparrow-arrow/src/hasher.rs
+++ b/crates/sparrow-arrow/src/hasher.rs
@@ -1,0 +1,322 @@
+// Based on hashing code from datafusion.
+
+use ahash::RandomState;
+use arrow_array::cast::{
+    as_boolean_array, as_generic_binary_array, as_largestring_array, as_primitive_array,
+    as_string_array, as_struct_array,
+};
+use arrow_array::types::{ArrowDictionaryKeyType, Decimal128Type, Decimal256Type};
+use arrow_array::{
+    downcast_dictionary_array, downcast_primitive_array, Array, ArrayAccessor, DictionaryArray,
+    FixedSizeBinaryArray,
+};
+use arrow_buffer::{i256, ArrowNativeType};
+use arrow_schema::DataType;
+
+pub struct Hasher {
+    random_state: RandomState,
+    hash_buffer: Vec<u64>,
+}
+
+impl Default for Hasher {
+    fn default() -> Self {
+        let random_state = ahash::random_state::RandomState::with_seeds(1234, 5678, 9012, 3456);
+        Self {
+            random_state,
+            hash_buffer: Default::default(),
+        }
+    }
+}
+
+#[derive(derive_more::Display, Debug)]
+pub enum Error {
+    #[display(fmt = "must have at least one array to hash")]
+    NoArraysToHash,
+    #[display(fmt = "hash of '{_0:?}' unsupported")]
+    UnsupportedType(DataType),
+}
+
+impl error_stack::Context for Error {}
+
+impl Hasher {
+    pub fn hash_array(
+        &mut self,
+        array: impl std::borrow::Borrow<dyn Array>,
+    ) -> error_stack::Result<&[u64], Error> {
+        self.hash_arrays(&[array.borrow()])
+    }
+
+    pub fn hash_arrays(
+        &mut self,
+        arrays: &[impl std::borrow::Borrow<dyn Array>],
+    ) -> error_stack::Result<&[u64], Error> {
+        error_stack::ensure!(!arrays.is_empty(), Error::NoArraysToHash);
+
+        let num_rows = arrays[0].borrow().len();
+
+        self.hash_buffer.clear();
+        self.hash_buffer.resize(num_rows, 0);
+        create_hashes(arrays, &self.random_state, &mut self.hash_buffer, false)?;
+
+        Ok(&self.hash_buffer)
+    }
+}
+
+/// Creates hash values for every row, based on the values in the
+/// columns.
+///
+/// The number of rows to hash is determined by `hashes_buffer.len()`.
+/// `hashes_buffer` should be pre-sized appropriately
+#[allow(clippy::ptr_arg)]
+fn create_hashes(
+    arrays: &[impl std::borrow::Borrow<dyn Array>],
+    random_state: &RandomState,
+    hashes_buffer: &mut Vec<u64>,
+    mut multi_col: bool,
+) -> error_stack::Result<(), Error> {
+    for col in arrays {
+        let array = col.borrow();
+        downcast_primitive_array! {
+            array => hash_array(array, random_state, hashes_buffer, multi_col),
+            DataType::Null => hash_null(random_state, hashes_buffer, multi_col),
+            DataType::Boolean => hash_array(as_boolean_array(array), random_state, hashes_buffer, multi_col),
+            DataType::Utf8 => hash_array(as_string_array(array), random_state, hashes_buffer, multi_col),
+            DataType::LargeUtf8 => hash_array(as_largestring_array(array), random_state, hashes_buffer, multi_col),
+            DataType::Binary => hash_array(as_generic_binary_array::<i32>(array), random_state, hashes_buffer, multi_col),
+            DataType::LargeBinary => hash_array(as_generic_binary_array::<i64>(array), random_state, hashes_buffer, multi_col),
+            DataType::FixedSizeBinary(_) => {
+                let array: &FixedSizeBinaryArray = array.as_any().downcast_ref().unwrap();
+                hash_array(array, random_state, hashes_buffer, multi_col)
+            }
+            DataType::Decimal128(_, _) => {
+                let array = as_primitive_array::<Decimal128Type>(array);
+                hash_array(array, random_state, hashes_buffer, multi_col)
+            }
+            DataType::Decimal256(_, _) => {
+                let array = as_primitive_array::<Decimal256Type>(array);
+                hash_array(array, random_state, hashes_buffer, multi_col)
+            }
+            DataType::Dictionary(_, _) => downcast_dictionary_array! {
+                array => hash_dictionary(array, random_state, hashes_buffer, multi_col)?,
+                _ => unreachable!()
+            }
+            DataType::Struct(_) => {
+                let array = as_struct_array(array);
+                create_hashes(array.columns(), random_state, hashes_buffer, multi_col)?;
+            }
+            unsupported => {
+                // This is internal because we should have caught this before.
+                error_stack::bail!(Error::UnsupportedType(unsupported.clone()))
+            }
+        }
+
+        multi_col = true;
+    }
+
+    Ok(())
+}
+
+#[inline]
+fn combine_hashes(l: u64, r: u64) -> u64 {
+    let hash = (17 * 37u64).wrapping_add(l);
+    hash.wrapping_mul(37).wrapping_add(r)
+}
+
+fn hash_null(random_state: &RandomState, hashes_buffer: &'_ mut [u64], mul_col: bool) {
+    if mul_col {
+        hashes_buffer.iter_mut().for_each(|hash| {
+            // stable hash for null value
+            *hash = combine_hashes(random_state.hash_one(1), *hash);
+        })
+    } else {
+        hashes_buffer.iter_mut().for_each(|hash| {
+            *hash = random_state.hash_one(1);
+        })
+    }
+}
+
+trait HashValue {
+    fn hash_one(&self, state: &RandomState) -> u64;
+}
+
+impl<'a, T: HashValue + ?Sized> HashValue for &'a T {
+    fn hash_one(&self, state: &RandomState) -> u64 {
+        T::hash_one(self, state)
+    }
+}
+
+macro_rules! hash_value {
+    ($($t:ty),+) => {
+        $(impl HashValue for $t {
+            fn hash_one(&self, state: &RandomState) -> u64 {
+                state.hash_one(self)
+            }
+        })+
+    };
+}
+hash_value!(i8, i16, i32, i64, i128, i256, u8, u16, u32, u64);
+hash_value!(bool, str, [u8]);
+
+macro_rules! hash_float_value {
+    ($(($t:ty, $i:ty)),+) => {
+        $(impl HashValue for $t {
+            fn hash_one(&self, state: &RandomState) -> u64 {
+                state.hash_one(<$i>::from_ne_bytes(self.to_ne_bytes()))
+            }
+        })+
+    };
+}
+hash_float_value!((half::f16, u16), (f32, u32), (f64, u64));
+
+fn hash_array<T>(array: T, random_state: &RandomState, hashes_buffer: &mut [u64], multi_col: bool)
+where
+    T: ArrayAccessor,
+    T::Item: HashValue,
+{
+    if array.null_count() == 0 {
+        if multi_col {
+            for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+                *hash = combine_hashes(array.value(i).hash_one(random_state), *hash);
+            }
+        } else {
+            for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+                *hash = array.value(i).hash_one(random_state);
+            }
+        }
+    } else if multi_col {
+        for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+            if !array.is_null(i) {
+                *hash = combine_hashes(array.value(i).hash_one(random_state), *hash);
+            }
+        }
+    } else {
+        for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+            if !array.is_null(i) {
+                *hash = array.value(i).hash_one(random_state);
+            }
+        }
+    }
+}
+
+/// Hash the values in a dictionary array
+fn hash_dictionary<K: ArrowDictionaryKeyType>(
+    array: &DictionaryArray<K>,
+    random_state: &RandomState,
+    hashes_buffer: &mut [u64],
+    multi_col: bool,
+) -> error_stack::Result<(), Error> {
+    // Hash each dictionary value once, and then use that computed
+    // hash for each key value to avoid a potentially expensive
+    // redundant hashing for large dictionary elements (e.g. strings)
+    let values = array.values().clone();
+    let mut dict_hashes = vec![0; values.len()];
+    create_hashes(&[values], random_state, &mut dict_hashes, false)?;
+
+    // combine hash for each index in values
+    if multi_col {
+        for (hash, key) in hashes_buffer.iter_mut().zip(array.keys().iter()) {
+            if let Some(key) = key {
+                *hash = combine_hashes(dict_hashes[key.as_usize()], *hash)
+            } // no update for Null, consistent with other hashes
+        }
+    } else {
+        for (hash, key) in hashes_buffer.iter_mut().zip(array.keys().iter()) {
+            if let Some(key) = key {
+                *hash = dict_hashes[key.as_usize()]
+            } // no update for Null, consistent with other hashes
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{StringArray, UInt64Array};
+    use arrow_array::StructArray;
+    use arrow_schema::{Field, Fields};
+
+    use super::*;
+
+    #[test]
+    fn test_hash_uint64() {
+        let mut hasher = Hasher::default();
+        let array = UInt64Array::from(vec![Some(5), None, Some(8), Some(5), None]);
+        let array: &dyn Array = &array;
+
+        let hashes = hasher.hash_array(array).unwrap();
+        assert_eq!(hashes[0], hashes[3]);
+        assert_eq!(hashes[1], hashes[4]);
+        assert_ne!(hashes[0], hashes[1]);
+        assert_ne!(hashes[0], hashes[2]);
+    }
+
+    #[test]
+    fn test_hash_string() {
+        let array = StringArray::from(vec![
+            Some("hello"),
+            None,
+            Some("world"),
+            Some("hello"),
+            None,
+        ]);
+        let mut hasher = Hasher::default();
+        let array: &dyn Array = &array;
+
+        let hashes = hasher.hash_array(array).unwrap();
+        assert_eq!(hashes[0], hashes[3]);
+        assert_eq!(hashes[1], hashes[4]);
+        assert_ne!(hashes[0], hashes[1]);
+        assert_ne!(hashes[0], hashes[2]);
+    }
+
+    #[test]
+    fn test_hash_string_stability() {
+        let mut hasher = Hasher::default();
+        let array = StringArray::from(vec![Some("hello"), None, Some("world")]);
+        let array: &dyn Array = &array;
+
+        let hashes = hasher.hash_array(array).unwrap();
+        assert_eq!(hashes, &[1472103086483932002, 0, 8057155968893317866]);
+    }
+
+    #[test]
+    fn test_hash_struct() {
+        let mut hasher = Hasher::default();
+        let n_array = UInt64Array::from(vec![Some(5), None, Some(8), Some(5), Some(5), None]);
+        let s_array = StringArray::from(vec![
+            Some("hello"),
+            None,
+            Some("world"),
+            Some("hello"),
+            Some("world"),
+            None,
+        ]);
+        let array = StructArray::new(
+            Fields::from(vec![
+                Field::new("n", n_array.data_type().clone(), true),
+                Field::new("s", s_array.data_type().clone(), true),
+            ]),
+            vec![Arc::new(n_array), Arc::new(s_array)],
+            None,
+        );
+        let array: &dyn Array = &array;
+
+        let hashes = hasher.hash_array(array).unwrap();
+        // 0: ("hello", 5)
+        // 1: (null, null)
+        // 2: ("world", 8)
+        // 3: ("hello", 5)
+        // 4: ("world", 5)
+        // 5: (null, null)
+
+        assert_eq!(hashes[0], hashes[3]);
+        assert_eq!(hashes[1], hashes[5]);
+        assert_ne!(hashes[0], hashes[1]);
+        assert_ne!(hashes[0], hashes[2]);
+        assert_ne!(hashes[2], hashes[4]);
+        assert_ne!(hashes[3], hashes[4]);
+        assert_ne!(hashes[4], hashes[5]);
+    }
+}

--- a/crates/sparrow-arrow/src/lib.rs
+++ b/crates/sparrow-arrow/src/lib.rs
@@ -12,6 +12,8 @@ pub mod attachments;
 pub mod avro;
 mod batch;
 pub mod downcast;
+pub mod hash;
+pub mod hasher;
 mod row_time;
 pub mod scalar_value;
 pub mod serde;

--- a/crates/sparrow-compiler/src/types/inference.rs
+++ b/crates/sparrow-compiler/src/types/inference.rs
@@ -590,7 +590,7 @@ fn promote_concrete(concrete: FenlType, constraint: &TypeConstraint) -> Option<F
 
         // Keys include anything we can currently hash.
         (TypeConstraint::Key, FenlType::Concrete(actual_type)) => {
-            if sparrow_kernels::hash::can_hash(actual_type) {
+            if sparrow_arrow::hash::can_hash(actual_type) {
                 Some(concrete)
             } else {
                 None

--- a/crates/sparrow-instructions/src/evaluators/general.rs
+++ b/crates/sparrow-instructions/src/evaluators/general.rs
@@ -34,7 +34,7 @@ pub(super) struct HashEvaluator {
 impl Evaluator for HashEvaluator {
     fn evaluate(&mut self, info: &dyn RuntimeInfo) -> anyhow::Result<ArrayRef> {
         let input = info.value(&self.input)?.array_ref()?;
-        let result = sparrow_kernels::hash::hash(input.as_ref())?;
+        let result = sparrow_arrow::hash::hash(input.as_ref())?;
         Ok(Arc::new(result))
     }
 }

--- a/crates/sparrow-kernels/Cargo.toml
+++ b/crates/sparrow-kernels/Cargo.toml
@@ -11,7 +11,6 @@ Computation kernels defined over Arrow arrays.
 
 [dependencies]
 anyhow.workspace = true
-ahash.workspace = true
 arrow.workspace = true
 bitvec.workspace = true
 chrono.workspace = true

--- a/crates/sparrow-kernels/src/lib.rs
+++ b/crates/sparrow-kernels/src/lib.rs
@@ -9,7 +9,6 @@
     clippy::print_stderr,
     clippy::undocumented_unsafe_blocks
 )]
-pub mod hash;
 pub mod lag;
 mod ordered_cast;
 pub mod string;

--- a/crates/sparrow-runtime/src/execute/operation/lookup_request.rs
+++ b/crates/sparrow-runtime/src/execute/operation/lookup_request.rs
@@ -137,7 +137,7 @@ impl LookupRequestOperation {
 
         // Re-key to the foreign key and hash it.
         let foreign_key_hash = input.column(self.foreign_key_column).clone();
-        let foreign_key_hash = sparrow_kernels::hash::hash(&foreign_key_hash)?;
+        let foreign_key_hash = sparrow_arrow::hash::hash(&foreign_key_hash)?;
 
         // Now, we need to determine how many actual foreign rows there are and collect
         // the requesting primary keys.

--- a/crates/sparrow-runtime/src/execute/operation/with_key.rs
+++ b/crates/sparrow-runtime/src/execute/operation/with_key.rs
@@ -104,7 +104,7 @@ impl WithKeyOperation {
 
         // Hash the new key column
         let new_keys = input.column(self.new_key_input_index);
-        let new_key_hashes = sparrow_kernels::hash::hash(new_keys)?;
+        let new_key_hashes = sparrow_arrow::hash::hash(new_keys)?;
         let time = input.column(0);
         let subsort = input.column(1);
 

--- a/crates/sparrow-runtime/src/prepare/column_behavior.rs
+++ b/crates/sparrow-runtime/src/prepare/column_behavior.rs
@@ -282,7 +282,7 @@ impl ColumnBehavior {
                     }
                 );
 
-                let entity_column = sparrow_kernels::hash::hash(column)
+                let entity_column = sparrow_arrow::hash::hash(column)
                     .into_report()
                     .change_context(Error::PreparingColumn)?;
 

--- a/crates/sparrow-runtime/src/prepare/slice_preparer.rs
+++ b/crates/sparrow-runtime/src/prepare/slice_preparer.rs
@@ -9,7 +9,6 @@ use hashbrown::HashSet;
 use sparrow_api::kaskada::v1alpha::slice_plan;
 use sparrow_arrow::downcast::downcast_primitive_array;
 use sparrow_core::context_code;
-use sparrow_kernels::hash::hash;
 
 use crate::prepare::Error;
 
@@ -48,7 +47,7 @@ impl SlicePreparer {
                         entity_keys.null_count()
                     )
                 );
-                let entity_key_hashes = hash(&entity_keys)?;
+                let entity_key_hashes = sparrow_arrow::hash::hash(&entity_keys)?;
                 let entity_key_hashes: &UInt64Array = downcast_primitive_array(&entity_key_hashes)?;
                 let desired_keys: HashSet<u64> =
                     entity_key_hashes.values().iter().copied().collect();
@@ -126,7 +125,7 @@ impl SlicePreparer {
         record_batch: &RecordBatch,
     ) -> error_stack::Result<UInt64Array, Error> {
         let entity_column = record_batch.column(self.entity_column_index);
-        hash(entity_column)
+        sparrow_arrow::hash::hash(entity_column)
             .into_report()
             .change_context(Error::SlicingBatch)
     }


### PR DESCRIPTION
Also add a `Hasher` that hashes into a re-usable buffer. This tends to speed up the hash operation. The `Hasher` supports hashing of structs and other types that we didn't previously support.