### PR TITLE
feat: use explicit type variable in signatures

### DIFF
--- a/crates/sparrow-compiler/src/functions/aggregation.rs
+++ b/crates/sparrow-compiler/src/functions/aggregation.rs
@@ -8,9 +8,9 @@ const AGGREGATION_IS_NEW: &str = "(logical_or ?window_is_new ?input_is_new)";
 
 pub(super) fn register(registry: &mut Registry) {
     registry
-        .register("count_if(input: any, window: window = null) -> u32")
+        .register("count_if<T: any>(input: T, window: window = null) -> u32")
         .with_dfg_signature(
-            "count_if(input: any, window: window = null, duration: i64 = null) -> u32",
+            "count_if<T: any>(input: T, window: window = null, duration: i64 = null) -> u32",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(count_if ({}) ({}) ({}))",
@@ -22,9 +22,9 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("count(input: any, window: window = null) -> u32")
+        .register("count<T: any>(input: T, window: window = null) -> u32")
         .with_dfg_signature(
-            "count_if(input: any, window: window = null, duration: i64 = null) -> u32",
+            "count_if<T: any>(input: T, window: window = null, duration: i64 = null) -> u32",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(count_if ({}) ({}) ({}))",
@@ -37,9 +37,9 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("sum(input: number, window: window = null) -> number")
+        .register("sum<N: number>(input: N, window: window = null) -> N ")
         .with_dfg_signature(
-            "sum(input: number, window: window = null, duration: i64 = null) -> number",
+            "sum<N: number>(input: N, window: window = null, duration: i64 = null) -> N",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(sum ({}) ({}) ({}))",
@@ -51,9 +51,9 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("min(input: ordered, window: window = null) -> ordered")
+        .register("min<O: ordered>(input: O, window: window = null) -> O")
         .with_dfg_signature(
-            "min(input: ordered, window: window = null, duration: i64 = null) -> ordered",
+            "min<O: ordered>(input: O, window: window = null, duration: i64 = null) -> O",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(min ({}) ({}) ({}))",
@@ -65,9 +65,9 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("max(input: ordered, window: window = null) -> ordered")
+        .register("max<O: ordered>(input: O, window: window = null) -> O")
         .with_dfg_signature(
-            "max(input: ordered, window: window = null, duration: i64 = null) -> ordered",
+            "max<O: ordered>(input: O, window: window = null, duration: i64 = null) -> O",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(max ({}) ({}) ({}))",
@@ -79,9 +79,9 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("mean(input: number, window: window = null) -> f64")
+        .register("mean<N: number>(input: N, window: window = null) -> f64")
         .with_dfg_signature(
-            "mean(input: number, window: window = null, duration: i64 = null) -> f64",
+            "mean<N: number>(input: N, window: window = null, duration: i64 = null) -> f64",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(mean ({}) ({}) ({}))",
@@ -93,9 +93,9 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("variance(input: number, window: window = null) -> f64")
+        .register("variance<N: number>(input: N, window: window = null) -> f64")
         .with_dfg_signature(
-            "variance(input: number, window: window = null, duration: i64 = null) -> f64",
+            "variance<N: number>(input: N, window: window = null, duration: i64 = null) -> f64",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(variance ({}) ({}) ({}))",
@@ -107,9 +107,9 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("stddev(input: number, window: window = null) -> f64")
+        .register("stddev<N: number>(input: N, window: window = null) -> f64")
         .with_dfg_signature(
-            "stddev(input: number, window: window = null, duration: i64 = null) -> f64",
+            "stddev<N: number>(input: N, window: window = null, duration: i64 = null) -> f64",
         )
         .with_implementation(Implementation::new_pattern(&format!(
             "(powf (variance ({}) ({}) ({})) 0.5f64)",
@@ -120,8 +120,10 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("last(input: any, window: window = null) -> any")
-        .with_dfg_signature("last(input: any, window: window = null, duration: i64 = null) -> any")
+        .register("last<T: any>(input: T, window: window = null) -> T")
+        .with_dfg_signature(
+            "last<T: any>(input: T, window: window = null, duration: i64 = null) -> T",
+        )
         .with_implementation(Implementation::Pushdown(Box::new(
             Pushdown::try_new(
                 0,
@@ -160,8 +162,10 @@ pub(super) fn register(registry: &mut Registry) {
         .with_time_domain_check(TimeDomainCheck::Aggregation);
 
     registry
-        .register("first(input: any, window: window = null) -> any")
-        .with_dfg_signature("first(input: any, window: window = null, duration: i64 = null) -> any")
+        .register("first<T: any>(input: T, window: window = null) -> T")
+        .with_dfg_signature(
+            "first<T: any>(input: T, window: window = null, duration: i64 = null) -> T",
+        )
         .with_implementation(Implementation::Pushdown(Box::new(
             Pushdown::try_new(
                 0,

--- a/crates/sparrow-compiler/src/functions/comparison.rs
+++ b/crates/sparrow-compiler/src/functions/comparison.rs
@@ -4,26 +4,26 @@ use crate::functions::{Implementation, Registry};
 
 pub(super) fn register(registry: &mut Registry) {
     registry
-        .register("eq(a: any, b: any) -> bool")
+        .register("eq<T: any>(a: T, b: T) -> bool")
         .with_implementation(Implementation::Instruction(InstOp::Eq));
 
     registry
-        .register("neq(a: any, b: any) -> bool")
+        .register("neq<T: any>(a: T, b: T) -> bool")
         .with_implementation(Implementation::Instruction(InstOp::Neq));
 
     registry
-        .register("lt(a: ordered, b: ordered) -> bool")
+        .register("lt<O: ordered>(a: O, b: O) -> bool")
         .with_implementation(Implementation::Instruction(InstOp::Lt));
 
     registry
-        .register("gt(a: ordered, b: ordered) -> bool")
+        .register("gt<O: ordered>(a: O, b: O) -> bool")
         .with_implementation(Implementation::Instruction(InstOp::Gt));
 
     registry
-        .register("lte(a: ordered, b: ordered) -> bool")
+        .register("lte<O: ordered>(a: O, b: O) -> bool")
         .with_implementation(Implementation::Instruction(InstOp::Lte));
 
     registry
-        .register("gte(a: ordered, b: ordered) -> bool")
+        .register("gte<O: ordered>(a: O, b: O) -> bool")
         .with_implementation(Implementation::Instruction(InstOp::Gte));
 }

--- a/crates/sparrow-compiler/src/functions/general.rs
+++ b/crates/sparrow-compiler/src/functions/general.rs
@@ -4,15 +4,15 @@ use crate::functions::{Implementation, Registry};
 
 pub(super) fn register(registry: &mut Registry) {
     registry
-        .register("is_valid(input: any) -> bool")
+        .register("is_valid<T: any>(input: T) -> bool")
         .with_implementation(Implementation::Instruction(InstOp::IsValid));
 
     registry
-        .register("hash(input: key) -> u64")
+        .register("hash<K: key>(input: K) -> u64")
         .with_implementation(Implementation::Instruction(InstOp::Hash));
 
     registry
-        .register("with_key(key: key, value: any, const grouping: string = null) -> any")
+        .register("with_key<K: key, T: any>(key: K, value: T, const grouping: string = null) -> T")
         .with_implementation(Implementation::new_pattern({
             const MERGED_OP: &str = "(merge_join ?key_op ?value_op)";
             const MERGED_KEY: &str = const_format::formatcp!("(transform ?key_value {MERGED_OP})");
@@ -31,7 +31,7 @@ pub(super) fn register(registry: &mut Registry) {
         ));
 
     registry
-        .register("lookup(key: key, value: any) -> any")
+        .register("lookup<K: key, T: any>(key: K, value: T) -> T")
         .with_implementation(Implementation::new_pattern({
             // The operation of the lookup request depends on the key value.
             //
@@ -87,6 +87,6 @@ pub(super) fn register(registry: &mut Registry) {
         }));
 
     registry
-        .register("coalesce(values+: any) -> any")
+        .register("coalesce<T: any>(values+: T) -> T")
         .with_implementation(Implementation::Instruction(InstOp::Coalesce));
 }

--- a/crates/sparrow-compiler/src/functions/logical.rs
+++ b/crates/sparrow-compiler/src/functions/logical.rs
@@ -16,14 +16,14 @@ pub(super) fn register(registry: &mut Registry) {
         .with_implementation(Implementation::Instruction(InstOp::LogicalAnd));
 
     registry
-        .register("if(condition: bool, value: any) -> any")
+        .register("if<T: any>(condition: bool, value: T) -> T")
         .with_implementation(Implementation::Instruction(InstOp::If));
 
     registry
-        .register("null_if(condition: bool, value: any) -> any")
+        .register("null_if<T: any>(condition: bool, value: T) -> T")
         .with_implementation(Implementation::Instruction(InstOp::NullIf));
 
     registry
-        .register("else(default: any, value: any) -> any")
+        .register("else<T: any>(default: T, value: T) -> T")
         .with_implementation(Implementation::new_fenl_rewrite("coalesce(value, default)"));
 }

--- a/crates/sparrow-compiler/src/functions/math.rs
+++ b/crates/sparrow-compiler/src/functions/math.rs
@@ -4,43 +4,43 @@ use crate::functions::{Implementation, Registry};
 
 pub(super) fn register(registry: &mut Registry) {
     registry
-        .register("neg(n: signed) -> signed")
+        .register("neg<S: signed>(n: S) -> S")
         .with_implementation(Implementation::Instruction(InstOp::Neg));
 
     registry
-        .register("ceil(n: number) -> number")
+        .register("ceil<N: number>(n: N) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Ceil));
 
     registry
-        .register("round(n: number) -> number")
+        .register("round<N: number>(n: N) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Round));
 
     registry
-        .register("floor(n: number) -> number")
+        .register("floor<N: number>(n: N) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Floor));
 
     registry
-        .register("add(a: number, b: number) -> number")
+        .register("add<N: number>(a: N, b: N) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Add));
 
     registry
-        .register("sub(a: number, b: number) -> number")
+        .register("sub<N: number>(a: N, b: N) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Sub));
 
     registry
-        .register("mul(a: number, b: number) -> number")
+        .register("mul<N: number>(a: N, b: N) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Mul));
 
     registry
-        .register("div(a: number, b: number) -> number")
+        .register("div<N: number>(a: N, b: N) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Div));
 
     registry
-        .register("zip_min(a: ordered, b: ordered) -> ordered")
+        .register("zip_min<O: ordered>(a: O, b: O) -> O")
         .with_implementation(Implementation::Instruction(InstOp::ZipMin));
 
     registry
-        .register("zip_max(a: ordered, b: ordered) -> ordered")
+        .register("zip_max<O: ordered>(a: O, b: O) -> O")
         .with_implementation(Implementation::Instruction(InstOp::ZipMax));
 
     registry
@@ -48,7 +48,7 @@ pub(super) fn register(registry: &mut Registry) {
         .with_implementation(Implementation::Instruction(InstOp::Powf));
 
     registry
-        .register("sqrt(a: number) -> f64")
+        .register("sqrt<N: number>(a: N) -> f64")
         .with_implementation(Implementation::new_fenl_rewrite("powf(a, 0.5)"));
 
     registry
@@ -56,6 +56,6 @@ pub(super) fn register(registry: &mut Registry) {
         .with_implementation(Implementation::Instruction(InstOp::Exp));
 
     registry
-        .register("clamp(value: number, min: number = null, max: number = null) -> number")
+        .register("clamp<N: number>(value: N, min: N = null, max: N = null) -> N")
         .with_implementation(Implementation::Instruction(InstOp::Clamp));
 }

--- a/crates/sparrow-compiler/src/functions/time.rs
+++ b/crates/sparrow-compiler/src/functions/time.rs
@@ -5,11 +5,11 @@ use crate::functions::{Implementation, Registry};
 
 pub(super) fn register(registry: &mut Registry) {
     registry
-        .register("time_of(input: any) -> timestamp_ns")
+        .register("time_of<T: any>(input: T) -> timestamp_ns")
         .with_implementation(Implementation::Instruction(InstOp::TimeOf));
 
     registry
-        .register("when(condition: bool, value: any) -> any")
+        .register("when<T: any>(condition: bool, value: T) -> T")
         .with_implementation(Implementation::new_pattern(
             "(transform (transform ?value_value (merge_join ?condition_op ?value_op)) (select \
              (transform ?condition_value (merge_join ?condition_op ?value_op))))",
@@ -42,7 +42,7 @@ pub(super) fn register(registry: &mut Registry) {
         ));
 
     registry
-        .register("shift_to(time: timestamp_ns, value: any) -> any")
+        .register("shift_to<T: any>(time: timestamp_ns, value: T) -> T")
         .with_implementation(Implementation::new_pattern(
             "(transform ?value_value (shift_to ?time_value))",
         ))
@@ -53,7 +53,7 @@ pub(super) fn register(registry: &mut Registry) {
 
     // Shift by is a macro expansion of shift to, hence it shared the same time domain check
     registry
-        .register("shift_by(delta: timedelta, value: any) -> any")
+        .register("shift_by<T: any, D: timedelta>(delta: D, value: T) -> T")
         .with_implementation(Implementation::new_fenl_rewrite(
             "shift_to(add_time(delta, time_of(value)), value)",
         ))
@@ -103,11 +103,11 @@ pub(super) fn register(registry: &mut Registry) {
         .with_implementation(Implementation::Instruction(InstOp::Seconds));
 
     registry
-        .register("add_time(delta: timedelta, time: timestamp_ns) -> timestamp_ns")
+        .register("add_time<D: timedelta>(delta: D, time: timestamp_ns) -> timestamp_ns")
         .with_implementation(Implementation::Instruction(InstOp::AddTime));
 
     registry
-        .register("shift_until(predicate: bool, value: any) -> any")
+        .register("shift_until<T: any>(predicate: bool, value: T) -> T")
         .with_implementation(Implementation::new_pattern(
             "(transform (transform ?value_value (merge_join ?value_op ?predicate_op)) \
              (shift_until (transform ?predicate_value (merge_join ?value_op ?predicate_op))))",
@@ -132,6 +132,6 @@ pub(super) fn register(registry: &mut Registry) {
 
     // Note: Lag is specifically *not* an aggregation function.
     registry
-        .register("lag(const n: i64, input: ordered) -> ordered")
+        .register("lag<O: ordered>(const n: i64, input: O) -> O")
         .with_implementation(Implementation::Instruction(InstOp::Lag));
 }

--- a/crates/sparrow-main/tests/e2e/basic_error_tests.rs
+++ b/crates/sparrow-main/tests/e2e/basic_error_tests.rs
@@ -619,14 +619,16 @@ async fn test_invalid_type_ident() {
     message: 1 errors in Fenl statements; see diagnostics
     fenl_diagnostics:
       - severity: error
-        code: E0011
-        message: Invalid syntax
+        code: E0002
+        message: Illegal cast
         formatted:
-          - "error[E0011]: Invalid syntax"
+          - "error[E0002]: Illegal cast"
           - "  --> Query:1:19"
           - "  |"
           - "1 | { n: Numbers.n as ben } "
-          - "  |                   ^^^ Invalid Fenl Type 'ben'"
+          - "  |                   ^^^ Unable to cast to type 'ben'"
+          - "  |"
+          - "  = From type i64"
           - ""
           - ""
     "###);

--- a/crates/sparrow-plan/src/inst.rs
+++ b/crates/sparrow-plan/src/inst.rs
@@ -48,21 +48,21 @@ pub enum Mode {
 )]
 #[display(style = "snake_case")]
 pub enum InstOp {
-    #[strum(props(signature = "add(a: number, b: number) -> number"))]
+    #[strum(props(signature = "add<N: number>(a: N, b: N) -> N"))]
     Add,
-    #[strum(props(signature = "add_time(delta: timedelta, time: timestamp_ns) -> timestamp_ns"))]
-    AddTime,
-    #[strum(props(signature = "ceil(n: number) -> number"))]
-    Ceil,
     #[strum(props(
-        signature = "clamp(value: number, min: number = null, max: number = null) -> number"
+        signature = "add_time<D: timedelta>(delta: D, time: timestamp_ns) -> timestamp_ns"
     ))]
+    AddTime,
+    #[strum(props(signature = "ceil<N: number>(n: N) -> N"))]
+    Ceil,
+    #[strum(props(signature = "clamp<N: number>(value: N, min: N = null, max: N = null) -> N"))]
     Clamp,
-    #[strum(props(signature = "coalesce(values+: any) -> any"))]
+    #[strum(props(signature = "coalesce<T: any>(values+: T) -> T"))]
     Coalesce,
     #[strum(props(
-        dfg_signature = "count_if(input: any, window: window = null) -> u32",
-        plan_signature = "count_if(input: any, ticks: bool = null, slide_duration: i64 = null) -> \
+        dfg_signature = "count_if<T: any>(input: T, window: window = null) -> u32",
+        plan_signature = "count_if<T: any>(input: T, ticks: bool = null, slide_duration: i64 = null) -> \
                           u32"
     ))]
     CountIf,
@@ -80,28 +80,28 @@ pub enum InstOp {
         signature = "days_between(t1: timestamp_ns, t2: timestamp_ns) -> interval_days"
     ))]
     DaysBetween,
-    #[strum(props(signature = "div(a: number, b: number) -> number"))]
+    #[strum(props(signature = "div<N: number>(a: N, b: N) -> N"))]
     Div,
-    #[strum(props(signature = "eq(a: any, b: any) -> bool"))]
+    #[strum(props(signature = "eq<T: any>(a: T, b: T) -> bool"))]
     Eq,
     #[strum(props(signature = "exp(power: f64) -> f64"))]
     Exp,
     #[strum(props(
-        dfg_signature = "first(input: any, window: window = null) -> any",
-        plan_signature = "first(input: any, ticks: bool = null, slide_duration: i64 = null) -> any"
+        dfg_signature = "first<T: any>(input: T, window: window = null) -> T",
+        plan_signature = "first<T: any>(input: T, ticks: bool = null, slide_duration: i64 = null) -> T"
     ))]
     First,
-    #[strum(props(signature = "floor(n: number) -> number"))]
+    #[strum(props(signature = "floor<N: number>(n: N) -> N"))]
     Floor,
-    #[strum(props(signature = "gt(a: ordered, b: ordered) -> bool"))]
+    #[strum(props(signature = "gt<O: ordered>(a: O, b: O) -> bool"))]
     Gt,
-    #[strum(props(signature = "gte(a: ordered, b: ordered) -> bool"))]
+    #[strum(props(signature = "gte<O: ordered>(a: O, b: O) -> bool"))]
     Gte,
-    #[strum(props(signature = "hash(input: any) -> u64"))]
+    #[strum(props(signature = "hash<T: any>(input: T) -> u64"))]
     Hash,
-    #[strum(props(signature = "if(condition: bool, value: any) -> any"))]
+    #[strum(props(signature = "if<T: any>(condition: bool, value: T) -> T"))]
     If,
-    #[strum(props(signature = "is_valid(input: any) -> bool"))]
+    #[strum(props(signature = "is_valid<T: any>(input: T) -> bool"))]
     IsValid,
     // HACK: This instruction does not show up in the plan/does not have an evaluator.
     // It is converted to `JsonField` during simplification.
@@ -109,11 +109,11 @@ pub enum InstOp {
     Json,
     #[strum(props(signature = "json_field(s: string, field: string) -> string"))]
     JsonField,
-    #[strum(props(signature = "lag(n: i64, input: ordered) -> ordered"))]
+    #[strum(props(signature = "lag<O: ordered>(n: i64, input: O) -> O"))]
     Lag,
     #[strum(props(
-        dfg_signature = "last(input: any, window: window = null) -> any",
-        plan_signature = "last(input: any, ticks: bool = null, slide_duration: i64 = null) -> any"
+        dfg_signature = "last<T: any>(input: T, window: window = null) -> T",
+        plan_signature = "last<T: any>(input: T, ticks: bool = null, slide_duration: i64 = null) -> T"
     ))]
     Last,
     #[strum(props(signature = "len(s: string) -> i32"))]
@@ -124,26 +124,24 @@ pub enum InstOp {
     LogicalOr,
     #[strum(props(signature = "lower(s: string) -> string"))]
     Lower,
-    #[strum(props(signature = "lt(a: ordered, b: ordered) -> bool"))]
+    #[strum(props(signature = "lt<O: ordered>(a: O, b: O) -> bool"))]
     Lt,
-    #[strum(props(signature = "lte(a: ordered, b: ordered) -> bool"))]
+    #[strum(props(signature = "lte<O: ordered>(a: O, b: O) -> bool"))]
     Lte,
     #[strum(props(
-        dfg_signature = "max(input: ordered, window: window = null) -> ordered",
-        plan_signature = "max(input: ordered, ticks: bool = null, slide_duration: i64 = null) -> \
-                          ordered"
+        dfg_signature = "max<O: ordered>(input: O, window: window = null) -> O",
+        plan_signature = "max<O: ordered>(input: O, ticks: bool = null, slide_duration: i64 = null) -> O"
     ))]
     Max,
     #[strum(props(
-        dfg_signature = "mean(input: number, window: window = null) -> f64",
-        plan_signature = "mean(input: number, ticks: bool = null, slide_duration: i64 = null) -> \
+        dfg_signature = "mean<N: number>(input: N, window: window = null) -> f64",
+        plan_signature = "mean<N: number>(input: N, ticks: bool = null, slide_duration: i64 = null) -> \
                           f64"
     ))]
     Mean,
     #[strum(props(
-        dfg_signature = "min(input: ordered, window: window = null) -> ordered",
-        plan_signature = "min(input: ordered, ticks: bool = null, slide_duration: i64 = null) -> \
-                          ordered"
+        dfg_signature = "min<O: ordered>(input: O, window: window = null) -> O",
+        plan_signature = "min<O: ordered>(input: O, ticks: bool = null, slide_duration: i64 = null) -> O"
     ))]
     Min,
     #[strum(props(signature = "month_of_year(time: timestamp_ns) -> u32"))]
@@ -156,19 +154,19 @@ pub enum InstOp {
         signature = "months_between(t1: timestamp_ns, t2: timestamp_ns) -> interval_months"
     ))]
     MonthsBetween,
-    #[strum(props(signature = "mul(a: number, b: number) -> number"))]
+    #[strum(props(signature = "mul<N: number>(a: N, b: N) -> N"))]
     Mul,
-    #[strum(props(signature = "neg(n: signed) -> signed"))]
+    #[strum(props(signature = "neg<S: signed>(n: S) -> S"))]
     Neg,
-    #[strum(props(signature = "neq(a: any, b: any) -> bool"))]
+    #[strum(props(signature = "neq<T: any>(a: T, b: T) -> bool"))]
     Neq,
     #[strum(props(signature = "not(input: bool) -> bool"))]
     Not,
-    #[strum(props(signature = "null_if(condition: bool, value: any) -> any"))]
+    #[strum(props(signature = "null_if<T: any>(condition: bool, value: T) -> T"))]
     NullIf,
     #[strum(props(signature = "powf(base: f64, power: f64) -> f64"))]
     Powf,
-    #[strum(props(signature = "round(n: number) -> number"))]
+    #[strum(props(signature = "round<N: number>(n: N) -> N"))]
     Round,
     #[strum(props(signature = "seconds(seconds: i64) -> duration_s"))]
     Seconds,
@@ -176,33 +174,33 @@ pub enum InstOp {
         signature = "seconds_between(t1: timestamp_ns, t2: timestamp_ns) -> duration_s"
     ))]
     SecondsBetween,
-    #[strum(props(signature = "sub(a: number, b: number) -> number"))]
+    #[strum(props(signature = "sub<N: number>(a: N, b: N) -> N"))]
     Sub,
     #[strum(props(
         signature = "substring(s: string, start: i64 = null, end: i64 = null) -> string"
     ))]
     Substring,
     #[strum(props(
-        dfg_signature = "sum(input: number, window: window = null) -> number",
-        plan_signature = "sum(input: number, ticks: bool = null, slide_duration: i64 = null) -> \
-                          number"
+        dfg_signature = "sum<N: number>(input: N, window: window = null) -> N",
+        plan_signature = "sum<N: number>(input: N, ticks: bool = null, slide_duration: i64 = null) -> \
+                          N"
     ))]
     Sum,
-    #[strum(props(signature = "time_of(input: any) -> timestamp_ns"))]
+    #[strum(props(signature = "time_of<T: any>(input: T) -> timestamp_ns"))]
     TimeOf,
     #[strum(props(signature = "upper(s: string) -> string"))]
     Upper,
     #[strum(props(
-        dfg_signature = "variance(input: number, window: window = null) -> f64",
-        plan_signature = "variance(input: number, ticks: bool = null, slide_duration: i64 = null) \
+        dfg_signature = "variance<N: number>(input: N, window: window = null) -> f64",
+        plan_signature = "variance<N: number>(input: N, ticks: bool = null, slide_duration: i64 = null) \
                           -> f64"
     ))]
     Variance,
     #[strum(props(signature = "year(time: timestamp_ns) -> i32"))]
     Year,
-    #[strum(props(signature = "zip_max(a: ordered, b: ordered) -> ordered"))]
+    #[strum(props(signature = "zip_max<O: ordered>(a: O, b: O) -> O"))]
     ZipMax,
-    #[strum(props(signature = "zip_min(a: ordered, b: ordered) -> ordered"))]
+    #[strum(props(signature = "zip_min<O: ordered>(a: O, b: O) -> O"))]
     ZipMin,
 }
 

--- a/crates/sparrow-syntax/src/parser/grammar.lalrpop
+++ b/crates/sparrow-syntax/src/parser/grammar.lalrpop
@@ -238,10 +238,30 @@ Param: (Located<&'input str>, bool, Located<FenlType>, Option<Located<ExprRef>>,
     (name, is_const.is_some(), fenl_type, default.map(|(_, e)| e), is_vararg.is_some()),
 }
 
+TypeParams: Vec<TypeParameter> = {
+  "<" <params:Comma<TypeParameter>> ">" => params.to_vec()
+}
+
+pub(crate) TypeParameter: TypeParameter = {
+  <name:ident> ":" <l:@L> <constraint:Located<Constraint>> <r:@R> =>
+    TypeParameter::new(name.to_owned(), vec![constraint.inner().clone()])
+}
+
 pub(crate) Signature: Signature = {
-  <name:ident> "(" <l:@L> <parameters:Params> <r:@R> ")" "->" <result:Type> =>?
-    Signature::try_new(name.to_owned(), parameters, result).map_err(|e|
+  <name:ident> <type_params:TypeParams?> "(" <l:@L> <parameters:Params> <r:@R> ")" "->" <result:Type> =>?
+    Signature::try_new(name.to_owned(), parameters, type_params.unwrap_or_default(), result).map_err(|e|
       ParseError::User{ error: (l, e.to_string(), r) })
+}
+
+Constraint: TypeConstraint = {
+  <l:@L> <name:ident> <r:@R> => TypeConstraint::from_str(name).unwrap_or_else(|e| {
+    errors.push(ParseError::User{ error: (l, format!("Invalid Type Constraint '{}'", name), r)});
+    e
+  }),
+  ! => {
+    errors.push(<>.error);
+    TypeConstraint::Error
+  }
 }
 
 Type: FenlType = {

--- a/crates/sparrow-syntax/src/syntax/arguments.rs
+++ b/crates/sparrow-syntax/src/syntax/arguments.rs
@@ -666,13 +666,12 @@ mod tests {
         .map(|resolved| resolved.into_iter().map(|expr| expr.into_inner()).collect())
     }
 
-    const POW_SIGNATURE: &str = "pow(power:number, base:number) -> number";
-    const CLAMP_SIGNATURE: &str =
-        "clamp(value: number, min:number=null, max:number=null) -> number";
-    const LOG_SIGNATURE: &str = "log(power:f64, base:f64 = e) -> f64";
+    const POW_SIGNATURE: &str = "pow<N: number>(power: N, base: N) -> N";
+    const CLAMP_SIGNATURE: &str = "clamp<N: number>(value: N, min: N = null, max: N = null) -> N";
+    const LOG_SIGNATURE: &str = "log(power: f64, base: f64 = e) -> f64";
     const SUBSTRING_SIGNATURE: &str =
-        "substring(str: string, start: i32=null, end:i32=null) -> string";
-    const COALESCE_SIGNATURE: &str = "coalesce(values+: any) -> any";
+        "substring(str: string, start: i32 = null, end: i32 = null) -> string";
+    const COALESCE_SIGNATURE: &str = "coalesce<T: any>(values+: T) -> T";
 
     #[test]
     fn resolve_pow_positional_explicit_input() {
@@ -957,9 +956,9 @@ mod tests {
             op: Literal(Located(
               value: Null,
               location: Location(
-                part: Internal("clamp(value: number, min:number=null, max:number=null) -> number"),
-                start: 49,
-                end: 53,
+                part: Internal("clamp<N: number>(value: N, min: N = null, max: N = null) -> N"),
+                start: 51,
+                end: 55,
               ),
             )),
             args: Arguments([]),
@@ -988,9 +987,9 @@ mod tests {
             op: Literal(Located(
               value: Null,
               location: Location(
-                part: Internal("clamp(value: number, min:number=null, max:number=null) -> number"),
-                start: 32,
-                end: 36,
+                part: Internal("clamp<N: number>(value: N, min: N = null, max: N = null) -> N"),
+                start: 36,
+                end: 40,
               ),
             )),
             args: Arguments([]),
@@ -1041,9 +1040,9 @@ mod tests {
             op: Literal(Located(
               value: Null,
               location: Location(
-                part: Internal("clamp(value: number, min:number=null, max:number=null) -> number"),
-                start: 49,
-                end: 53,
+                part: Internal("clamp<N: number>(value: N, min: N = null, max: N = null) -> N"),
+                start: 51,
+                end: 55,
               ),
             )),
             args: Arguments([]),
@@ -1072,9 +1071,9 @@ mod tests {
             op: Literal(Located(
               value: Null,
               location: Location(
-                part: Internal("clamp(value: number, min:number=null, max:number=null) -> number"),
-                start: 32,
-                end: 36,
+                part: Internal("clamp<N: number>(value: N, min: N = null, max: N = null) -> N"),
+                start: 36,
+                end: 40,
               ),
             )),
             args: Arguments([]),
@@ -1145,9 +1144,9 @@ mod tests {
             op: Reference(Located(
               value: "e",
               location: Location(
-                part: Internal("log(power:f64, base:f64 = e) -> f64"),
-                start: 26,
-                end: 27,
+                part: Internal("log(power: f64, base: f64 = e) -> f64"),
+                start: 28,
+                end: 29,
               ),
             )),
             args: Arguments([]),
@@ -1176,9 +1175,9 @@ mod tests {
             op: Reference(Located(
               value: "e",
               location: Location(
-                part: Internal("log(power:f64, base:f64 = e) -> f64"),
-                start: 26,
-                end: 27,
+                part: Internal("log(power: f64, base: f64 = e) -> f64"),
+                start: 28,
+                end: 29,
               ),
             )),
             args: Arguments([]),
@@ -1207,9 +1206,9 @@ mod tests {
             op: Reference(Located(
               value: "e",
               location: Location(
-                part: Internal("log(power:f64, base:f64 = e) -> f64"),
-                start: 26,
-                end: 27,
+                part: Internal("log(power: f64, base: f64 = e) -> f64"),
+                start: 28,
+                end: 29,
               ),
             )),
             args: Arguments([]),
@@ -1238,9 +1237,9 @@ mod tests {
             op: Reference(Located(
               value: "e",
               location: Location(
-                part: Internal("log(power:f64, base:f64 = e) -> f64"),
-                start: 26,
-                end: 27,
+                part: Internal("log(power: f64, base: f64 = e) -> f64"),
+                start: 28,
+                end: 29,
               ),
             )),
             args: Arguments([]),
@@ -1380,9 +1379,9 @@ mod tests {
             op: Literal(Located(
               value: Null,
               location: Location(
-                part: Internal("substring(str: string, start: i32=null, end:i32=null) -> string"),
-                start: 48,
-                end: 52,
+                part: Internal("substring(str: string, start: i32 = null, end: i32 = null) -> string"),
+                start: 53,
+                end: 57,
               ),
             )),
             args: Arguments([]),
@@ -1411,9 +1410,9 @@ mod tests {
             op: Literal(Located(
               value: Null,
               location: Location(
-                part: Internal("substring(str: string, start: i32=null, end:i32=null) -> string"),
-                start: 34,
-                end: 38,
+                part: Internal("substring(str: string, start: i32 = null, end: i32 = null) -> string"),
+                start: 36,
+                end: 40,
               ),
             )),
             args: Arguments([]),
@@ -1541,7 +1540,7 @@ mod tests {
     fn should_report_positional_after_keyword() {
         // fun(a = zero, 5)
         insta::assert_ron_snapshot!(
-          test_resolve_exprs("fun(a: number, b: string) -> string", "a = zero, 5"), @r###"
+          test_resolve_exprs("fun<N: number>(a: N, b: string) -> string", "a = zero, 5"), @r###"
         Err(PositionalAfterKeyword(
           keyword: Location(
             part: Internal("a = zero, 5"),
@@ -1561,7 +1560,7 @@ mod tests {
     fn should_report_invalid_named_argument() {
         // fun(c = zero, 5)
         insta::assert_ron_snapshot!(
-          test_resolve_exprs("fun(a: number, b: string) -> string", "c = zero, b = 5"), @r###"
+          test_resolve_exprs("fun<N: number>(a: N, b: string) -> string", "c = zero, b = 5"), @r###"
         Err(InvalidKeywordArgument(
           keyword: Located(
             value: "c",
@@ -1579,7 +1578,7 @@ mod tests {
     fn should_report_too_many_arguments() {
         // fun(1, 2, 3)
         insta::assert_ron_snapshot!(
-          test_resolve_exprs("fun(a: number, b: string) -> number", "1, 2, 3"), @r###"
+          test_resolve_exprs("fun<N: number>(a: N, b: string) -> N", "1, 2, 3"), @r###"
         Err(TooManyArguments(
           expected: 2,
           actual: 3,
@@ -1596,7 +1595,7 @@ mod tests {
     fn should_report_too_many_missing_arguments() {
         // fun(1)
         insta::assert_ron_snapshot!(
-          test_resolve_exprs("fun(a: number, b: string, c: number) -> number", "1"), @r###"
+          test_resolve_exprs("fun<N: number>(a: N, b: string, c: N) -> N", "1"), @r###"
         Err(NotEnoughArguments(
           expected: 3,
           actual: 1,
@@ -1608,7 +1607,7 @@ mod tests {
     fn should_report_duplicate_keyword_arguments() {
         // fun(a = 1, a = 3)
         insta::assert_ron_snapshot!(
-          test_resolve_exprs("fun(a: number, b: string) -> string", "a = 1, a = 3"), @r###"
+          test_resolve_exprs("fun<N: number>(a: N, b: string) -> string", "a = 1, a = 3"), @r###"
         Err(InvalidKeywordArgument(
           keyword: Located(
             value: "a",
@@ -1626,7 +1625,7 @@ mod tests {
     fn should_report_duplicate_keyword_positional_arguments() {
         // fun(1, a = 2)
         insta::assert_ron_snapshot!(
-          test_resolve_exprs("fun(a: number, b: string) -> string", "1, a = 2"), @r###"
+          test_resolve_exprs("fun<N: number>(a: N, b: string) -> string", "1, a = 2"), @r###"
         Err(DuplicateKeywordAndPositional(
           keyword: Location(
             part: Internal("1, a = 2"),


### PR DESCRIPTION
Step 1 of many to support generic types for collections. 

Adds type variable struct to signatures. 

Next step supports nested generics, like `Map<K,V>`