### PR TITLE
test: Use gproto matchers for schemas

### DIFF
--- a/tests/integration/api/go.mod
+++ b/tests/integration/api/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/jt-nti/gproto v0.0.0-20210304092907-23e645af1351 // indirect
 	github.com/kaskada-ai/kaskada/wren v0.0.0-00010101000000-000000000000 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect

--- a/tests/integration/api/go.sum
+++ b/tests/integration/api/go.sum
@@ -532,6 +532,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jt-nti/gproto v0.0.0-20210304092907-23e645af1351 h1:jYsiD6zdBzctjZ4sDB+gGJJPB3NROHrUuCp/wUj5p9Y=
+github.com/jt-nti/gproto v0.0.0-20210304092907-23e645af1351/go.mod h1:yfoLDf8VFUCWSxFJsPuQT5BlqdDbGkDl5m6hzABroMI=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -648,6 +650,7 @@ github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
 github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
@@ -930,6 +933,7 @@ golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/tests/integration/api/query_v1_csv_test.go
+++ b/tests/integration/api/query_v1_csv_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/jt-nti/gproto"
 	v1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 	helpers "github.com/kaskada-ai/kaskada/tests/integration/shared/helpers"
 	. "github.com/kaskada-ai/kaskada/tests/integration/shared/matchers"
@@ -115,11 +116,12 @@ min_amount: query_v1_test_csv.amount | min(),
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Config.DataTokenId).ShouldNot(BeEmpty())
 				Expect(firstResponse.GetDestination().GetObjectStore().GetOutputPaths().GetPaths()).Should(BeNil())
+
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 			})
 		})
@@ -144,10 +146,10 @@ min_amount: query_v1_test_csv.amount | min(),
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Config.DataTokenId).Should(Equal(firstDataTokenId))
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 				_, err = uuid.Parse(secondResponse.QueryId)
 				Expect(err).Should(BeNil())

--- a/tests/integration/api/query_v1_incremental_shift_test.go
+++ b/tests/integration/api/query_v1_incremental_shift_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/jt-nti/gproto"
 	v1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 	helpers "github.com/kaskada-ai/kaskada/tests/integration/shared/helpers"
 	. "github.com/kaskada-ai/kaskada/tests/integration/shared/matchers"
@@ -120,11 +121,11 @@ min_amount: query_v1_inc_shift.amount | min(),
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Config.DataTokenId).Should(Equal(firstDataTokenId))
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-					primitiveSchemaField("shifted_time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+					gproto.Equal(primitiveSchemaField("shifted_time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 				_, err = uuid.Parse(secondResponse.QueryId)
 				Expect(err).Should(BeNil())
@@ -424,10 +425,10 @@ min_amount: query_v1_inc_shift.amount | min(),
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Config.DataTokenId).Should(Equal(firstDataTokenId))
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 				_, err = uuid.Parse(secondResponse.QueryId)
 				Expect(err).Should(BeNil())

--- a/tests/integration/api/query_v1_incremental_test.go
+++ b/tests/integration/api/query_v1_incremental_test.go
@@ -14,6 +14,8 @@ import (
 	v1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 	helpers "github.com/kaskada-ai/kaskada/tests/integration/shared/helpers"
 	. "github.com/kaskada-ai/kaskada/tests/integration/shared/matchers"
+
+	"github.com/jt-nti/gproto"
 )
 
 var _ = Describe("Query V1 with incremental", Ordered, func() {
@@ -122,10 +124,10 @@ min_amount: purchases_incremental.amount | min(),
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Config.DataTokenId).Should(Equal(firstDataTokenId))
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 				_, err = uuid.Parse(secondResponse.QueryId)
 				Expect(err).Should(BeNil())
@@ -399,10 +401,10 @@ min_amount: purchases_incremental.amount | min(),
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Config.DataTokenId).Should(Equal(firstDataTokenId))
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 				_, err = uuid.Parse(secondResponse.QueryId)
 				Expect(err).Should(BeNil())

--- a/tests/integration/api/query_v1_multiple_table_test.go
+++ b/tests/integration/api/query_v1_multiple_table_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/jt-nti/gproto"
 	v1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 	helpers "github.com/kaskada-ai/kaskada/tests/integration/shared/helpers"
 	. "github.com/kaskada-ai/kaskada/tests/integration/shared/matchers"
@@ -77,7 +78,7 @@ var _ = Describe("Query V1 gRPC with multiple tables", Ordered, func() {
 			Expression: `
 # 1. Data Cleaning
 
-let meaningful_txns = Transaction 
+let meaningful_txns = Transaction
 | when(Transaction.price > 100)
 | when(time_of(Transaction.transaction_time) > ("2000-01-01T00:00:00Z" as timestamp_ns))
 
@@ -134,10 +135,10 @@ member_name : membership.name
 				Expect(firstResponse.GetDestination().GetObjectStore().GetOutputPaths().GetPaths()).Should(BeNil())
 
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("price", v1alpha.DataType_PRIMITIVE_TYPE_F64),
-					primitiveSchemaField("quantity", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("membership_date", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("member_name", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
+					gproto.Equal(primitiveSchemaField("price", v1alpha.DataType_PRIMITIVE_TYPE_F64)),
+					gproto.Equal(primitiveSchemaField("quantity", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("membership_date", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("member_name", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
 				))
 			})
 		})
@@ -161,10 +162,10 @@ member_name : membership.name
 				Expect(firstResponse.State).Should(Equal(v1alpha.CreateQueryResponse_STATE_ANALYSIS))
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("price", v1alpha.DataType_PRIMITIVE_TYPE_F64),
-					primitiveSchemaField("quantity", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("membership_date", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("member_name", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
+					gproto.Equal(primitiveSchemaField("price", v1alpha.DataType_PRIMITIVE_TYPE_F64)),
+					gproto.Equal(primitiveSchemaField("quantity", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("membership_date", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("member_name", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
 				))
 
 				_, err = uuid.Parse(secondResponse.QueryId)

--- a/tests/integration/api/query_v1_panic_test.go
+++ b/tests/integration/api/query_v1_panic_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/jt-nti/gproto"
 	v1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 	helpers "github.com/kaskada-ai/kaskada/tests/integration/shared/helpers"
 	. "github.com/kaskada-ai/kaskada/tests/integration/shared/matchers"
@@ -131,10 +132,10 @@ min_amount: query_v1_panic.amount | min(),
 		Expect(res.GetDestination().GetObjectStore().GetOutputPaths().Paths).Should(HaveLen(1))
 
 		Expect(res.Analysis.Schema).Should(ContainElements(
-			primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-			primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-			primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-			primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+			gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+			gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+			gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+			gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 		))
 
 		resultsUrl := res.GetDestination().GetObjectStore().GetOutputPaths().Paths[0]

--- a/tests/integration/api/query_v1_test.go
+++ b/tests/integration/api/query_v1_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/jt-nti/gproto"
 	v1alpha "github.com/kaskada-ai/kaskada/gen/proto/go/kaskada/kaskada/v1alpha"
 	helpers "github.com/kaskada-ai/kaskada/tests/integration/shared/helpers"
 	. "github.com/kaskada-ai/kaskada/tests/integration/shared/matchers"
@@ -116,10 +117,10 @@ min_amount: query_v1_test.amount | min(),
 				Expect(firstResponse.Config.DataTokenId).ShouldNot(BeEmpty())
 				Expect(firstResponse.GetDestination().GetObjectStore().GetOutputPaths().GetPaths()).Should(BeNil())
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 			})
 		})
@@ -144,10 +145,10 @@ min_amount: query_v1_test.amount | min(),
 				VerifyRequestDetails(firstResponse.RequestDetails)
 				Expect(firstResponse.Config.DataTokenId).Should(Equal(firstDataTokenId))
 				Expect(firstResponse.Analysis.Schema.GetFields()).Should(ContainElements(
-					primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND),
-					primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING),
-					primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
-					primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64),
+					gproto.Equal(primitiveSchemaField("time", v1alpha.DataType_PRIMITIVE_TYPE_TIMESTAMP_NANOSECOND)),
+					gproto.Equal(primitiveSchemaField("entity", v1alpha.DataType_PRIMITIVE_TYPE_STRING)),
+					gproto.Equal(primitiveSchemaField("max_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
+					gproto.Equal(primitiveSchemaField("min_amount", v1alpha.DataType_PRIMITIVE_TYPE_I64)),
 				))
 				_, err = uuid.Parse(secondResponse.QueryId)
 				Expect(err).Should(BeNil())


### PR DESCRIPTION
This uses a `gproto.Equal` matcher for the primitive schemas rather than just relying on them being equal.

It turns out, that protocol buffers have some "hidden" fields and won't always be actually equal (according to gomega's `Equal` matcher).

For instance -- printing a message before the assertion definitely causes it to fail. It seems like other cases may also cause it to fail (flakiness we were seeing after some other changes).

We should probably switch to using this anywhere we were matching protobufs.