### PR TITLE
bug: manager make directory for sqlite

### DIFF
--- a/wren/client/ent_client.go
+++ b/wren/client/ent_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -67,13 +66,11 @@ func NewEntConfig(dbDialect string, dbName *string, dbHost *string, inMemory *bo
 		log.Fatal().Msg("Flag: `db-dialect` must be set to either `postgres` or `sqlite`.")
 	}
 
-	if dbPath != nil && strings.HasPrefix(*dbPath, "~/") {
-		usr, err := user.Current()
+	if dbPath != nil {
+		path, err := filepath.Abs(*dbPath)
 		if err != nil {
-			log.Fatal().Msgf("unable to get local user account: %v", err)
+			log.Fatal().Msgf("invalid database path provided: %v", err)
 		}
-		dir := usr.HomeDir
-		path := filepath.Join(dir, (*dbPath)[2:])
 		err = os.MkdirAll(filepath.Dir(path), os.ModePerm)
 		if err != nil {
 			log.Fatal().Msgf("unable to create directories to path: %v", err)


### PR DESCRIPTION
Fixes one issue in #459. Updates the dbpath logic to merge the provided db path with the current path to produce an absolute path using the `abs` ([docs](https://pkg.go.dev/path/filepath#Abs)).

Previously, we were only checking for the home directory and not necessarily worrying about any other use cases. The logic proposed here should merge the two flows.