### PR TITLE
feat: Use object_store for metadata

### DIFF
--- a/crates/sparrow-catalog/src/update/execute_example.rs
+++ b/crates/sparrow-catalog/src/update/execute_example.rs
@@ -13,7 +13,6 @@ use sparrow_api::kaskada::v1alpha::{
 };
 use sparrow_compiler::InternalCompileOptions;
 use sparrow_qfr::kaskada::sparrow::v1alpha::FlightRecordHeader;
-use sparrow_runtime::s3::S3Helper;
 use sparrow_runtime::PreparedMetadata;
 use tempfile::NamedTempFile;
 use uuid::Uuid;
@@ -45,7 +44,6 @@ impl error_stack::Context for Error {}
 /// Execute the example and return the result as a CSV string.
 pub(super) async fn execute_example(
     example: &FunctionExample,
-    s3_helper: S3Helper,
 ) -> error_stack::Result<String, Error> {
     // 1. Prepare the file
     let mut preparer = ExampleInputPreparer::new();
@@ -106,7 +104,6 @@ pub(super) async fn execute_example(
             changed_since: None,
             final_result_time: None,
         },
-        s3_helper,
         None,
         None,
         FlightRecordHeader::default(),

--- a/crates/sparrow-main/src/batch.rs
+++ b/crates/sparrow-main/src/batch.rs
@@ -7,7 +7,6 @@ use sparrow_api::kaskada::v1alpha::execute_request::Limits;
 use sparrow_api::kaskada::v1alpha::{CompileRequest, ExecuteRequest, FenlDiagnostics};
 use sparrow_compiler::CompilerOptions;
 use sparrow_qfr::kaskada::sparrow::v1alpha::FlightRecordHeader;
-use sparrow_runtime::s3::S3Helper;
 use tracing::{info, info_span};
 
 use crate::script::{Schema, Script, ScriptPath};
@@ -112,8 +111,6 @@ impl BatchCommand {
         };
 
         if !self.compile_only {
-            let s3_helper = S3Helper::new().await;
-
             if !self.output_dir.exists() {
                 tokio::fs::create_dir_all(&self.output_dir)
                     .await
@@ -133,7 +130,6 @@ impl BatchCommand {
                     changed_since: None,
                     final_result_time: None,
                 },
-                s3_helper,
                 None,
                 self.flight_record_path,
                 FlightRecordHeader::default(),

--- a/crates/sparrow-main/src/materialize.rs
+++ b/crates/sparrow-main/src/materialize.rs
@@ -8,7 +8,6 @@ use sparrow_api::kaskada::v1alpha::{destination, CompileRequest, ExecuteRequest,
 
 use sparrow_compiler::CompilerOptions;
 use sparrow_qfr::kaskada::sparrow::v1alpha::FlightRecordHeader;
-use sparrow_runtime::s3::S3Helper;
 use tracing::{info, info_span};
 
 use crate::script::{Schema, Script, ScriptPath};
@@ -109,8 +108,6 @@ impl MaterializeCommand {
             error_stack::bail!(Error::InvalidQuery(diagnostics));
         };
 
-        let s3_helper = S3Helper::new().await;
-
         // Note: it might be cleaner to create a separate entry point for materialize, but for now it's ok.
         let result_stream = sparrow_runtime::execute::execute(
             ExecuteRequest {
@@ -122,7 +119,6 @@ impl MaterializeCommand {
                 changed_since: None,
                 final_result_time: None,
             },
-            s3_helper,
             Some(script.bounded_lateness_ns),
             self.flight_record_path,
             FlightRecordHeader::default(),

--- a/crates/sparrow-main/src/serve/compute_service.rs
+++ b/crates/sparrow-main/src/serve/compute_service.rs
@@ -272,7 +272,6 @@ async fn execute_impl(
 
     let progress_stream = sparrow_runtime::execute::execute(
         request,
-        s3_helper.clone(),
         None,
         flight_record_local_path,
         flight_record_header,

--- a/crates/sparrow-runtime/src/execute.rs
+++ b/crates/sparrow-runtime/src/execute.rs
@@ -43,7 +43,6 @@ const STORE_PATH_PREFIX: &str = "compute_snapshot_";
 /// execute response.
 pub async fn execute(
     request: ExecuteRequest,
-    s3_helper: S3Helper,
     bounded_lateness_ns: Option<i64>,
     _flight_record_local_path: Option<std::path::PathBuf>,
     _flight_record_header: FlightRecordHeader,
@@ -86,6 +85,8 @@ pub async fn execute(
     let mut data_context = DataContext::try_from_tables(request.tables.to_vec())
         .into_report()
         .change_context(Error::internal_msg("create data context"))?;
+
+    let s3_helper = S3Helper::new().await;
 
     // If the snapshot config exists, sparrow should attempt to resume from state,
     // and store new state. Create a new storage path for the local store to
@@ -156,6 +157,8 @@ pub async fn execute(
         None
     };
 
+    let object_stores = ObjectStoreRegistry::default();
+
     let primary_grouping_key_type = plan
         .primary_grouping_key_type
         .to_owned()
@@ -177,9 +180,8 @@ pub async fn execute(
         .change_context(Error::internal_msg("get primary grouping ID"))?;
 
     key_hash_inverse
-        .add_from_data_context(&data_context, primary_group_id, s3_helper.clone())
+        .add_from_data_context(&data_context, primary_group_id, &object_stores)
         .await
-        .into_report()
         .change_context(Error::internal_msg("initialize key hash inverse"))?;
     let key_hash_inverse = Arc::new(ThreadSafeKeyHashInverse::new(key_hash_inverse));
 
@@ -202,7 +204,7 @@ pub async fn execute(
     let context = OperationContext {
         plan,
         plan_hash,
-        object_stores: ObjectStoreRegistry::default(),
+        object_stores,
         data_context,
         compute_store,
         key_hash_inverse,
@@ -298,10 +300,10 @@ pub async fn materialize(
         .into_report()
         .change_context(Error::internal_msg("get primary grouping ID"))?;
 
+    let object_stores = ObjectStoreRegistry::default();
     key_hash_inverse
-        .add_from_data_context(&data_context, primary_group_id, s3_helper.clone())
+        .add_from_data_context(&data_context, primary_group_id, &object_stores)
         .await
-        .into_report()
         .change_context(Error::internal_msg("initialize key hash inverse"))?;
     let key_hash_inverse = Arc::new(ThreadSafeKeyHashInverse::new(key_hash_inverse));
 
@@ -315,7 +317,7 @@ pub async fn materialize(
     let context = OperationContext {
         plan,
         plan_hash,
-        object_stores: ObjectStoreRegistry::default(),
+        object_stores,
         data_context,
         compute_store: snapshot_compute_store,
         key_hash_inverse,

--- a/crates/sparrow-runtime/src/metadata/prepared_metadata.rs
+++ b/crates/sparrow-runtime/src/metadata/prepared_metadata.rs
@@ -96,7 +96,7 @@ impl PreparedMetadata {
             .unwrap_or(i64::MIN);
 
         let path = format!("file://{}", parquet_path.display());
-        let metadata_path = format!("{}", metadata_parquet_path.display());
+        let metadata_path = format!("file://{}", metadata_parquet_path.display());
         Self::try_from_prepared_schema(
             path,
             prepared_schema.clone(),

--- a/crates/sparrow-runtime/src/prepare.rs
+++ b/crates/sparrow-runtime/src/prepare.rs
@@ -296,9 +296,12 @@ async fn upload_prepared_files(
                     || Error::InvalidUrl(metadata_prepared_url.as_str().to_string()),
                 )?;
 
+            let local_path = prepared_metadata
+                .path
+                .strip_prefix("file://")
+                .expect("starts with file://");
             parquet_uploads.push(
-                object_store_registry
-                    .upload(prepare_object_store_url, Path::new(&prepared_metadata.path)),
+                object_store_registry.upload(prepare_object_store_url, Path::new(local_path)),
             );
 
             parquet_uploads.push(object_store_registry.upload(

--- a/wren/compute/helpers.go
+++ b/wren/compute/helpers.go
@@ -88,7 +88,7 @@ func getComputePreparedFiles(prepareJobs []*ent.PrepareJob) []*v1alpha.PreparedF
 				MaxEventTime: timestamppb.New(time.Unix(0, preparedFile.MaxEventTime)),
 				MinEventTime: timestamppb.New(time.Unix(0, preparedFile.MinEventTime)),
 				NumRows:      preparedFile.RowCount,
-				MetadataPath: ConvertURIForCompute(metadataPath),
+				MetadataPath: metadataPath,
 			})
 		}
 	}


### PR DESCRIPTION
This is part of #465.

This uses `object_store` to retrieve the metadata files. Additionally, it uses a `select_all` so that all metadata files are read concurrently.