### PR TITLE
feat: Use metadata for retrieving the schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,7 @@ dependencies = [
  "chrono",
  "clap 4.3.2",
  "criterion",
+ "dashmap",
  "data-encoding",
  "derive_more",
  "enum-map",

--- a/crates/sparrow-runtime/Cargo.toml
+++ b/crates/sparrow-runtime/Cargo.toml
@@ -29,6 +29,7 @@ bitvec.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true
+dashmap.workspace = true
 data-encoding.workspace = true
 derive_more.workspace = true
 enum-map.workspace = true

--- a/crates/sparrow-runtime/src/metadata/raw_metadata.rs
+++ b/crates/sparrow-runtime/src/metadata/raw_metadata.rs
@@ -127,6 +127,7 @@ impl RawMetadata {
     ///
     /// For CSV, this currently needs to download a local copy of the file, since
     /// Arrow does not (as of 2023-July-06) support reading CSV using `AsyncWrite`.
+    // TODO(https://github.com/kaskada-ai/kaskada/issues/486): Async CSV support.
     async fn try_from_csv(
         path: &str,
         object_stores: &ObjectStoreRegistry,

--- a/crates/sparrow-runtime/src/metadata/raw_metadata.rs
+++ b/crates/sparrow-runtime/src/metadata/raw_metadata.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use arrow::array::ArrowPrimitiveType;
 use arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef, TimestampMillisecondType};
 use error_stack::{IntoReport, IntoReportCompat, ResultExt};
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tempfile::NamedTempFile;
 
 use sparrow_api::kaskada::v1alpha::source_data::{self, Source};
@@ -13,7 +12,7 @@ use sparrow_api::kaskada::v1alpha::source_data::{self, Source};
 use sparrow_api::kaskada::v1alpha::PulsarConfig;
 
 use crate::metadata::file_from_path;
-use crate::stores::object_store_url::ObjectStoreKey;
+use crate::read::ParquetFile;
 use crate::stores::{ObjectStoreRegistry, ObjectStoreUrl};
 use crate::streams;
 
@@ -106,75 +105,57 @@ impl RawMetadata {
         })
     }
 
-    /// Create a `RawMetadata` from a parquet string path and object store registry
+    /// Create a `RawMetadata` from a parquet string path and object store registry.
+    ///
+    /// This uses `object_store` to asynchronously retrieve only the Parquet
+    /// footer to determine the schema.
     async fn try_from_parquet(
         path: &str,
-        object_store_registry: &ObjectStoreRegistry,
+        object_stores: &ObjectStoreRegistry,
     ) -> error_stack::Result<Self, Error> {
-        let object_store_url = ObjectStoreUrl::from_str(path)
+        let url = ObjectStoreUrl::from_str(path)
             .change_context_lazy(|| Error::ObjectStore(path.to_owned()))?;
-        let object_store_key = object_store_url
-            .key()
+
+        let parquet_file = ParquetFile::try_new(object_stores, url)
+            .await
             .change_context_lazy(|| Error::ObjectStore(path.to_owned()))?;
-        match object_store_key {
-            ObjectStoreKey::Local => {
-                let path = object_store_url
-                    .path()
-                    .change_context_lazy(|| Error::ObjectStore(path.to_owned()))?
-                    .to_string();
-                // The local paths are formatted file:///absolute/path/to/file.file
-                // The Object Store path strips the prefix file:/// but we need to add the
-                // root slash back prior to opening the file.
-                let path = format!("/{}", path);
-                let path = std::path::Path::new(&path);
-                Self::try_from_parquet_path(path)
-            }
-            _ => {
-                let download_file = NamedTempFile::new().map_err(|_| Error::Download)?;
-                object_store_url
-                    .download(object_store_registry, download_file.path())
-                    .await
-                    .change_context_lazy(|| Error::Download)?;
-                Self::try_from_parquet_path(download_file.path())
-            }
-        }
+
+        Self::from_raw_schema(parquet_file.schema)
     }
 
-    /// Create a `RawMetadata` from a CSV string path and object store registry
+    /// Create a `RawMetadata` from a CSV string path and object store registry.
+    ///
+    /// For CSV, this currently needs to download a local copy of the file, since
+    /// Arrow does not (as of 2023-July-06) support reading CSV using `AsyncWrite`.
     async fn try_from_csv(
         path: &str,
-        object_store_registry: &ObjectStoreRegistry,
+        object_stores: &ObjectStoreRegistry,
     ) -> error_stack::Result<Self, Error> {
         let object_store_url = ObjectStoreUrl::from_str(path)
             .change_context_lazy(|| Error::ObjectStore(path.to_owned()))?;
-        let object_store_key = object_store_url
-            .key()
-            .change_context_lazy(|| Error::ObjectStore(path.to_owned()))?;
-        match object_store_key {
-            ObjectStoreKey::Local => {
-                let path = object_store_url
-                    .path()
-                    .change_context_lazy(|| Error::ObjectStore(path.to_owned()))?
-                    .to_string();
-                let path = format!("/{}", path);
-                let file = file_from_path(std::path::Path::new(&path))
-                    .into_report()
-                    .change_context_lazy(|| Error::LocalFile)?;
-                Self::try_from_csv_reader(file)
-            }
-            _ => {
-                let download_file = NamedTempFile::new()
-                    .into_report()
-                    .change_context_lazy(|| Error::Download)?;
-                object_store_url
-                    .download(object_store_registry, download_file.path())
-                    .await
-                    .change_context_lazy(|| Error::Download)?;
-                let file = file_from_path(download_file.path())
-                    .into_report()
-                    .change_context_lazy(|| Error::Download)?;
-                Self::try_from_csv_reader(file)
-            }
+
+        if object_store_url.is_local() {
+            let path = object_store_url
+                .path()
+                .change_context_lazy(|| Error::ObjectStore(path.to_owned()))?
+                .to_string();
+            let path = format!("/{}", path);
+            let file = file_from_path(std::path::Path::new(&path))
+                .into_report()
+                .change_context_lazy(|| Error::LocalFile)?;
+            Self::try_from_csv_reader(file)
+        } else {
+            let download_file = NamedTempFile::new()
+                .into_report()
+                .change_context_lazy(|| Error::Download)?;
+            object_store_url
+                .download(object_stores, download_file.path())
+                .await
+                .change_context_lazy(|| Error::Download)?;
+            let file = file_from_path(download_file.path())
+                .into_report()
+                .change_context_lazy(|| Error::Download)?;
+            Self::try_from_csv_reader(file)
         }
     }
 
@@ -217,18 +198,6 @@ impl RawMetadata {
             user_schema: Arc::new(pulsar_schema),
             sparrow_metadata: Self::from_raw_schema(Arc::new(Schema::new(new_fields)))?,
         })
-    }
-
-    /// Create a `RawMetadata` fram a Parquet file path.
-    fn try_from_parquet_path(path: &std::path::Path) -> error_stack::Result<Self, Error> {
-        let file = file_from_path(path)
-            .into_report()
-            .change_context_lazy(|| Error::LocalFile)?;
-        let parquet_reader = ParquetRecordBatchReaderBuilder::try_new(file)
-            .into_report()
-            .change_context_lazy(|| Error::ReadSchema)?;
-        let raw_schema = parquet_reader.schema();
-        Self::from_raw_schema(raw_schema.clone())
     }
 
     /// Create a `RawMetadata` from a reader of a CSV file or string.

--- a/crates/sparrow-runtime/src/prepare.rs
+++ b/crates/sparrow-runtime/src/prepare.rs
@@ -154,7 +154,7 @@ pub async fn prepare_file(
         .change_context_lazy(|| Error::InvalidUrl(output_path_prefix.to_owned()))?;
 
     let object_store = object_stores
-        .object_store(output_url.key().change_context(Error::Internal)?)
+        .object_store(&output_url)
         .change_context(Error::Internal)?;
 
     let mut prepare_stream = prepared_batches(source_data, table_config, slice)

--- a/crates/sparrow-runtime/src/read/parquet_file.rs
+++ b/crates/sparrow-runtime/src/read/parquet_file.rs
@@ -45,13 +45,13 @@ impl ParquetFile {
     ///
     /// This will return an error if the file doesn't exist.
     pub async fn try_new(
-        registry: &ObjectStoreRegistry,
+        object_stores: &ObjectStoreRegistry,
         url: ObjectStoreUrl,
     ) -> error_stack::Result<Self, Error> {
-        let key = url.key().change_context(Error::InvalidUrl)?;
-        let object_store = registry
-            .object_store(key)
-            .change_context(Error::InvalidUrl)?;
+        let object_store = object_stores
+            .object_store(&url)
+            .change_context(Error::InvalidUrl)?
+            .clone();
         let path = url.path().change_context(Error::InvalidUrl)?;
 
         let metadata = get_parquet_metadata(object_store.as_ref(), &path).await?;

--- a/crates/sparrow-runtime/src/stores/object_store_url.rs
+++ b/crates/sparrow-runtime/src/stores/object_store_url.rs
@@ -50,7 +50,7 @@ impl ObjectStoreUrl {
         self.url.scheme() == "file"
     }
 
-    pub(super) fn key(&self) -> error_stack::Result<ObjectStoreKey, Error> {
+    pub fn key(&self) -> error_stack::Result<ObjectStoreKey, Error> {
         match self.url.scheme() {
             "file" => Ok(ObjectStoreKey::Local),
             "mem" => Ok(ObjectStoreKey::Memory),
@@ -177,7 +177,7 @@ impl std::fmt::Display for ObjectStoreUrl {
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-pub(super) enum ObjectStoreKey {
+pub enum ObjectStoreKey {
     Local,
     Memory,
     Aws {


### PR DESCRIPTION
This is part of #465.

This also simplifies the `ObjectStore` API to hide the `ObjectStoreKey`.