### PR TITLE
ref: Cleanup object_store code a bit

### DIFF
--- a/crates/sparrow-runtime/src/prepare.rs
+++ b/crates/sparrow-runtime/src/prepare.rs
@@ -102,12 +102,10 @@ pub async fn prepared_batches<'a>(
                 // For CSV we need to download the file (for now) to perform inference.
                 // We could improve this by looking at the size and creating an in-memory
                 // buffer and/or looking at a prefix of the file...
-                url.download(object_stores, local_file.path())
+                object_stores
+                    .download(url, local_file.path())
                     .await
-                    .change_context_lazy(|| Error::DownloadingObject {
-                        url,
-                        local: local_file.path().to_owned(),
-                    })?;
+                    .change_context(Error::DownloadingObject)?;
 
                 // Transfer the local file to the reader. When the CSV reader
                 // completes the reader will be dropped, and the file deleted.

--- a/crates/sparrow-runtime/src/prepare/error.rs
+++ b/crates/sparrow-runtime/src/prepare/error.rs
@@ -1,15 +1,7 @@
-use std::path::PathBuf;
-
 use url::Url;
-
-use crate::stores::ObjectStoreUrl;
 
 #[derive(derive_more::Display, Debug)]
 pub enum Error {
-    #[display(fmt = "unable to open '{path:?}'")]
-    OpenFile { path: PathBuf },
-    #[display(fmt = "unable to create '{path:?}'")]
-    CreateFile { path: PathBuf },
     #[display(fmt = "internal error")]
     Internal,
     #[display(fmt = "failed to create Parquet file reader")]
@@ -24,8 +16,6 @@ pub enum Error {
     PreparingColumn,
     #[display(fmt = "sorting batch")]
     SortingBatch,
-    #[display(fmt = "determine metadata")]
-    DetermineMetadata,
     #[display(fmt = "invalid schema provided")]
     ReadSchema,
     #[display(fmt = "failed to write to '{_0}")]
@@ -39,16 +29,8 @@ pub enum Error {
         slice_plan: String,
         table_config: String,
     },
-    #[display(fmt = "unsupported source {_0:?}")]
-    UnsupportedOutputPath(&'static str),
-    #[display(fmt = "invalid input path")]
-    InvalidInputPath,
-    #[display(fmt = "failed to read input")]
-    ReadInput,
-    #[display(fmt = "failed to upload result")]
-    UploadResult,
-    #[display(fmt = "downloading object {url} to path {}", "local.display()")]
-    DownloadingObject { url: ObjectStoreUrl, local: PathBuf },
+    #[display(fmt = "downloading object to prepare")]
+    DownloadingObject,
     #[display(fmt = "invalid url: {_0}")]
     InvalidUrl(String),
 }
@@ -58,10 +40,7 @@ impl error_stack::Context for Error {}
 impl sparrow_core::ErrorCode for Error {
     fn error_code(&self) -> tonic::Code {
         match self {
-            Self::MissingField(_) | Self::IncorrectSlicePlan { .. } | Self::InvalidInputPath => {
-                tonic::Code::InvalidArgument
-            }
-            Self::UnsupportedOutputPath(_) => tonic::Code::Unimplemented,
+            Self::MissingField(_) | Self::IncorrectSlicePlan { .. } => tonic::Code::InvalidArgument,
             _ => tonic::Code::Internal,
         }
     }

--- a/crates/sparrow-runtime/src/stores.rs
+++ b/crates/sparrow-runtime/src/stores.rs
@@ -1,7 +1,8 @@
 mod object_meta_ext;
+mod object_store_key;
 pub mod object_store_url;
-mod object_stores;
+mod registry;
 
 pub use object_meta_ext::ObjectMetaExt;
 pub use object_store_url::ObjectStoreUrl;
-pub use object_stores::ObjectStoreRegistry;
+pub use registry::ObjectStoreRegistry;

--- a/crates/sparrow-runtime/src/stores/object_store_key.rs
+++ b/crates/sparrow-runtime/src/stores/object_store_key.rs
@@ -1,0 +1,179 @@
+use itertools::Itertools;
+use url::Url;
+
+#[derive(derive_more::Display, Debug)]
+pub enum Error {
+    #[display(fmt = "missing host in URL '{_0}'")]
+    MissingHost(Url),
+    #[display(fmt = "unsupported scheme '{}' in URL '{_0}'", "_0.scheme()")]
+    UnsupportedScheme(Url),
+    #[display(fmt = "invalid path '{}' in URL '{_0}'", "_0.path()")]
+    InvalidPath(Url),
+    #[display(fmt = "missing host in URL '{_0}'")]
+    UnsupportedHost(Url),
+}
+
+impl error_stack::Context for Error {}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+pub(super) enum ObjectStoreKey {
+    Local,
+    Memory,
+    Aws {
+        bucket: String,
+        region: Option<String>,
+        virtual_hosted_style_request: bool,
+    },
+    Gcs {
+        bucket: String,
+    },
+}
+
+impl ObjectStoreKey {
+    pub(super) fn from_url(url: &Url) -> error_stack::Result<Self, Error> {
+        match url.scheme() {
+            "file" => Ok(Self::Local),
+            "mem" => Ok(Self::Memory),
+            // S3 is the traditional S3 prefix for reading from S3.
+            // S3a is the protocol designed for scalability with Hadoop reading in mind.
+            // See: https://aws.amazon.com/blogs/opensource/community-collaboration-the-s3a-story/
+            "s3" | "s3a" => {
+                let bucket = url
+                    .host_str()
+                    .ok_or_else(|| Error::MissingHost(url.clone()))?
+                    .to_owned();
+                // For traditional S3 paths, the `host` should be just the bucket.
+                // We use this as the key. The creation of the S3 object store will
+                // parse out the bucket and other parts of the URL as needed.
+                Ok(Self::Aws {
+                    bucket,
+                    region: None,
+                    virtual_hosted_style_request: false,
+                })
+            }
+            "https" => {
+                let host = url
+                    .host_str()
+                    .ok_or_else(|| Error::MissingHost(url.clone()))?;
+
+                match host.splitn(4, '.').collect_tuple() {
+                    Some(("s3", bucket, "amazonaws", "com")) => Ok(Self::Aws {
+                        bucket: bucket.to_owned(),
+                        region: None,
+                        virtual_hosted_style_request: false,
+                    }),
+                    Some((bucket, "s3", region, "amazonaws.com")) => Ok(Self::Aws {
+                        bucket: bucket.to_owned(),
+                        region: Some(region.to_owned()),
+                        virtual_hosted_style_request: true,
+                    }),
+                    Some((bucket, "storage", "googleapis", "com")) => Ok(Self::Gcs {
+                        bucket: bucket.to_owned(),
+                    }),
+                    Some(("storage", "cloud", "google", "com")) => {
+                        let mut path = url
+                            .path_segments()
+                            .ok_or_else(|| Error::InvalidPath(url.clone()))?;
+                        let bucket = path.next().ok_or_else(|| Error::InvalidPath(url.clone()))?;
+                        Ok(Self::Gcs {
+                            bucket: bucket.to_owned(),
+                        })
+                    }
+                    _ => error_stack::bail!(Error::UnsupportedHost(url.clone())),
+                }
+            }
+            "gs" => {
+                let bucket = url
+                    .host_str()
+                    .ok_or_else(|| Error::MissingHost(url.clone()))?
+                    .to_owned();
+                Ok(Self::Gcs { bucket })
+            }
+            _ => {
+                error_stack::bail!(Error::UnsupportedScheme(url.clone()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_from_url(url: &str) -> error_stack::Result<ObjectStoreKey, Error> {
+        let url = Url::parse(url).expect("valid URL");
+        ObjectStoreKey::from_url(&url)
+    }
+
+    #[test]
+    fn test_local_urls() {
+        assert_eq!(key_from_url("file:///foo").unwrap(), ObjectStoreKey::Local);
+        assert_eq!(key_from_url("FILE:///foo").unwrap(), ObjectStoreKey::Local);
+    }
+
+    #[test]
+    fn test_memory_urls() {
+        assert_eq!(key_from_url("mem:///foo").unwrap(), ObjectStoreKey::Memory);
+        assert_eq!(key_from_url("mem:foo").unwrap(), ObjectStoreKey::Memory);
+    }
+
+    #[test]
+    fn test_aws_urls() {
+        assert_eq!(
+            key_from_url("s3://bucket/path").unwrap(),
+            ObjectStoreKey::Aws {
+                bucket: "bucket".to_owned(),
+                region: None,
+                virtual_hosted_style_request: false,
+            }
+        );
+        assert_eq!(
+            key_from_url("s3a://bucket/foo").unwrap(),
+            ObjectStoreKey::Aws {
+                bucket: "bucket".to_owned(),
+                region: None,
+                virtual_hosted_style_request: false,
+            }
+        );
+        assert_eq!(
+            key_from_url("https://s3.bucket.amazonaws.com/foo").unwrap(),
+            ObjectStoreKey::Aws {
+                bucket: "bucket".to_owned(),
+                region: None,
+                virtual_hosted_style_request: false,
+            }
+        );
+        assert_eq!(
+            key_from_url("https://bucket.s3.region.amazonaws.com/foo").unwrap(),
+            ObjectStoreKey::Aws {
+                bucket: "bucket".to_owned(),
+                region: Some("region".to_owned()),
+                virtual_hosted_style_request: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_gcp_urls() {
+        assert_eq!(
+            key_from_url("gs://bucket/path").unwrap(),
+            ObjectStoreKey::Gcs {
+                bucket: "bucket".to_owned()
+            }
+        );
+
+        assert_eq!(
+            key_from_url("https://bucket.storage.googleapis.com/path").unwrap(),
+            ObjectStoreKey::Gcs {
+                bucket: "bucket".to_owned()
+            }
+        );
+
+        assert_eq!(
+            key_from_url("https://storage.cloud.google.com/bucket/path").unwrap(),
+            ObjectStoreKey::Gcs {
+                bucket: "bucket".to_owned()
+            }
+        );
+    }
+}

--- a/crates/sparrow-runtime/src/stores/object_store_url.rs
+++ b/crates/sparrow-runtime/src/stores/object_store_url.rs
@@ -3,14 +3,12 @@ use std::{path::Path, str::FromStr};
 use error_stack::{IntoReport, ResultExt};
 use serde::{Deserialize, Serialize};
 
-use tokio_util::io::StreamReader;
 use url::Url;
 
-use super::{object_stores::Error, ObjectStoreRegistry};
-use itertools::Itertools;
+use crate::stores::registry::Error;
 
 /// A string referring to a file in an object store.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ObjectStoreUrl {
     url: Url,
 }
@@ -20,7 +18,7 @@ impl ObjectStoreUrl {
     pub fn path(&self) -> error_stack::Result<object_store::path::Path, Error> {
         object_store::path::Path::parse(self.url.path())
             .into_report()
-            .change_context_lazy(|| Error::UrlInvalidPath(self.url.clone()))
+            .change_context_lazy(|| Error::InvalidUrl(self.url.to_string()))
     }
 
     pub fn url(&self) -> &Url {
@@ -42,114 +40,18 @@ impl ObjectStoreUrl {
             .url
             .join(input)
             .into_report()
-            .change_context(Error::InvalidUrl(input.to_owned()))?;
+            .change_context_lazy(|| Error::InvalidUrl(input.to_owned()))?;
         Ok(Self { url })
     }
 
-    pub fn is_local(&self) -> bool {
-        self.url.scheme() == "file"
-    }
-
-    pub fn key(&self) -> error_stack::Result<ObjectStoreKey, Error> {
-        match self.url.scheme() {
-            "file" => Ok(ObjectStoreKey::Local),
-            "mem" => Ok(ObjectStoreKey::Memory),
-            // S3 is the traditional S3 prefix for reading from S3.
-            // S3a is the protocol designed for scalability with Hadoop reading in mind.
-            // See: https://aws.amazon.com/blogs/opensource/community-collaboration-the-s3a-story/
-            "s3" | "s3a" => {
-                let bucket = self
-                    .url
-                    .host_str()
-                    .ok_or_else(|| Error::UrlMissingHost(self.url.clone()))?
-                    .to_owned();
-                // For traditional S3 paths, the `host` should be just the bucket.
-                // We use this as the key. The creation of the S3 object store will
-                // parse out the bucket and other parts of the URL as needed.
-                Ok(ObjectStoreKey::Aws {
-                    bucket,
-                    region: None,
-                    virtual_hosted_style_request: false,
-                })
-            }
-            "https" => {
-                let host = self
-                    .url
-                    .host_str()
-                    .ok_or_else(|| Error::UrlMissingHost(self.url.clone()))?;
-
-                match host.splitn(4, '.').collect_tuple() {
-                    Some(("s3", bucket, "amazonaws", "com")) => Ok(ObjectStoreKey::Aws {
-                        bucket: bucket.to_owned(),
-                        region: None,
-                        virtual_hosted_style_request: false,
-                    }),
-                    Some((bucket, "s3", region, "amazonaws.com")) => Ok(ObjectStoreKey::Aws {
-                        bucket: bucket.to_owned(),
-                        region: Some(region.to_owned()),
-                        virtual_hosted_style_request: true,
-                    }),
-                    Some((bucket, "storage", "googleapis", "com")) => Ok(ObjectStoreKey::Gcs {
-                        bucket: bucket.to_owned(),
-                    }),
-                    Some(("storage", "cloud", "google", "com")) => {
-                        let mut path = self
-                            .url
-                            .path_segments()
-                            .ok_or_else(|| Error::UrlInvalidPath(self.url.clone()))?;
-                        let bucket = path
-                            .next()
-                            .ok_or_else(|| Error::UrlInvalidPath(self.url.clone()))?;
-                        Ok(ObjectStoreKey::Gcs {
-                            bucket: bucket.to_owned(),
-                        })
-                    }
-                    _ => error_stack::bail!(Error::UrlUnsupportedHost(self.url.clone())),
-                }
-            }
-            "gs" => {
-                let bucket = self
-                    .url
-                    .host_str()
-                    .ok_or_else(|| Error::UrlMissingHost(self.url.clone()))?
-                    .to_owned();
-                Ok(ObjectStoreKey::Gcs { bucket })
-            }
-            _ => {
-                error_stack::bail!(Error::UrlUnsupportedScheme(self.url.clone()))
-            }
+    /// Return the local path, if this is a local file.
+    pub fn local_path(&self) -> Option<&Path> {
+        if self.url.scheme() == "file" {
+            let path = self.url.path();
+            Some(Path::new(path))
+        } else {
+            None
         }
-    }
-
-    /// Download the given object to the given local file path.
-    pub async fn download(
-        &self,
-        object_store_registry: &ObjectStoreRegistry,
-        file_path: &Path,
-    ) -> error_stack::Result<(), Error> {
-        let path = self.path()?;
-        let object_store = object_store_registry.object_store(self)?;
-
-        let download_error = || Error::DownloadingObject {
-            from: self.clone(),
-            to: file_path.to_owned(),
-        };
-        let stream = object_store
-            .get(&path)
-            .await
-            .into_report()
-            .change_context_lazy(download_error)?
-            .into_stream();
-        let mut file = tokio::fs::File::create(file_path)
-            .await
-            .into_report()
-            .change_context_lazy(download_error)?;
-        let mut body = StreamReader::new(stream);
-        tokio::io::copy(&mut body, &mut file)
-            .await
-            .into_report()
-            .change_context_lazy(download_error)?;
-        Ok(())
     }
 }
 
@@ -176,141 +78,38 @@ impl std::fmt::Display for ObjectStoreUrl {
     }
 }
 
-#[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-pub enum ObjectStoreKey {
-    Local,
-    Memory,
-    Aws {
-        bucket: String,
-        region: Option<String>,
-        virtual_hosted_style_request: bool,
-    },
-    Gcs {
-        bucket: String,
-    },
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_local_urls() {
-        let url = ObjectStoreUrl::from_str("file:///foo").unwrap();
-        assert_eq!(url.key().unwrap(), ObjectStoreKey::Local);
+    fn test_join() {
+        let directory = ObjectStoreUrl::from_str("s3://bucket/directory/").unwrap();
         assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("/foo").unwrap()
+            ObjectStoreUrl::from_str("s3://bucket/directory/path.foo").unwrap(),
+            directory.join("path.foo").unwrap()
         );
 
-        let url = ObjectStoreUrl::from_str("FILE:///foo").unwrap();
-        assert_eq!(url.key().unwrap(), ObjectStoreKey::Local);
+        let file = ObjectStoreUrl::from_str("s3://bucket/directory/file").unwrap();
         assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("/foo").unwrap()
+            ObjectStoreUrl::from_str("s3://bucket/directory/path.foo").unwrap(),
+            file.join("path.foo").unwrap()
         );
     }
 
     #[test]
-    fn test_memory_urls() {
-        let url = ObjectStoreUrl::from_str("mem:///foo").unwrap();
-        assert_eq!(url.key().unwrap(), ObjectStoreKey::Memory);
+    fn test_local_path() {
         assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("foo").unwrap()
-        );
-
-        let url = ObjectStoreUrl::from_str("mem:foo").unwrap();
-        assert_eq!(url.key().unwrap(), ObjectStoreKey::Memory);
-        assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("foo").unwrap()
-        );
-    }
-
-    #[test]
-    fn test_aws_urls() {
-        let url = ObjectStoreUrl::from_str("s3://bucket/path").unwrap();
-        assert_eq!(
-            url.key().unwrap(),
-            ObjectStoreKey::Aws {
-                bucket: "bucket".to_owned(),
-                region: None,
-                virtual_hosted_style_request: false,
-            }
+            ObjectStoreUrl::from_str("file:///absolute/path")
+                .unwrap()
+                .local_path(),
+            Some(Path::new("/absolute/path"))
         );
         assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("path").unwrap()
-        );
-
-        let url = ObjectStoreUrl::from_str("s3a://bucket/foo").unwrap();
-        assert_eq!(
-            url.key().unwrap(),
-            ObjectStoreKey::Aws {
-                bucket: "bucket".to_owned(),
-                region: None,
-                virtual_hosted_style_request: false,
-            }
-        );
-        assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("foo").unwrap()
-        );
-
-        let url = ObjectStoreUrl::from_str("https://s3.bucket.amazonaws.com/foo").unwrap();
-        assert_eq!(
-            url.key().unwrap(),
-            ObjectStoreKey::Aws {
-                bucket: "bucket".to_owned(),
-                region: None,
-                virtual_hosted_style_request: false,
-            }
-        );
-        assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("foo").unwrap()
-        );
-
-        let url = ObjectStoreUrl::from_str("https://bucket.s3.region.amazonaws.com/foo").unwrap();
-        assert_eq!(
-            url.key().unwrap(),
-            ObjectStoreKey::Aws {
-                bucket: "bucket".to_owned(),
-                region: Some("region".to_owned()),
-                virtual_hosted_style_request: true
-            }
-        );
-        assert_eq!(
-            url.path().unwrap(),
-            object_store::path::Path::parse("foo").unwrap()
-        );
-    }
-
-    #[test]
-    fn test_gcp_urls() {
-        let url = ObjectStoreUrl::from_str("gs://bucket/path").unwrap();
-        assert_eq!(
-            url.key().unwrap(),
-            ObjectStoreKey::Gcs {
-                bucket: "bucket".to_owned()
-            }
-        );
-
-        let url = ObjectStoreUrl::from_str("https://bucket.storage.googleapis.com/path").unwrap();
-        assert_eq!(
-            url.key().unwrap(),
-            ObjectStoreKey::Gcs {
-                bucket: "bucket".to_owned()
-            }
-        );
-
-        let url = ObjectStoreUrl::from_str("https://storage.cloud.google.com/bucket/path").unwrap();
-        assert_eq!(
-            url.key().unwrap(),
-            ObjectStoreKey::Gcs {
-                bucket: "bucket".to_owned()
-            }
+            ObjectStoreUrl::from_str("s3://bucket/directory/path.foo")
+                .unwrap()
+                .local_path(),
+            None
         );
     }
 }

--- a/crates/sparrow-runtime/src/stores/registry.rs
+++ b/crates/sparrow-runtime/src/stores/registry.rs
@@ -5,10 +5,10 @@ use dashmap::DashMap;
 use derive_more::Display;
 use error_stack::{IntoReport, ResultExt};
 use object_store::ObjectStore;
-use tokio::{fs, io::AsyncWriteExt};
-use url::Url;
+use tokio::io::AsyncWriteExt;
 
-use super::{object_store_url::ObjectStoreKey, ObjectStoreUrl};
+use crate::stores::object_store_key::ObjectStoreKey;
+use crate::stores::ObjectStoreUrl;
 
 /// Map from URL scheme to object store for that prefix.
 ///
@@ -35,7 +35,7 @@ impl ObjectStoreRegistry {
         &self,
         url: &ObjectStoreUrl,
     ) -> error_stack::Result<Arc<dyn ObjectStore>, Error> {
-        let key = url.key()?;
+        let key = ObjectStoreKey::from_url(url.url()).change_context(Error::InvalidObjectStore)?;
         match self.object_stores.entry(key) {
             dashmap::mapref::entry::Entry::Occupied(entry) => Ok(entry.get().clone()),
             dashmap::mapref::entry::Entry::Vacant(vacant) => {
@@ -47,32 +47,65 @@ impl ObjectStoreRegistry {
 
     pub async fn upload(
         &self,
-        target_url: ObjectStoreUrl,
-        local_file_path: &path::Path,
+        source_path: &path::Path,
+        destination_url: ObjectStoreUrl,
     ) -> error_stack::Result<(), Error> {
-        let target_path = target_url.path()?;
-        let object_store = self.object_store(&target_url)?;
-        let mut local_file = fs::File::open(local_file_path)
+        let target_path = destination_url.path()?;
+        let object_store = self.object_store(&destination_url)?;
+
+        let upload_error = || Error::UploadingObject {
+            from: source_path.to_path_buf(),
+            to: destination_url.clone(),
+        };
+        let mut source = tokio::fs::File::open(source_path)
             .await
             .into_report()
-            .change_context(Error::Internal)?;
-        let (_id, mut writer) = object_store
+            .change_context_lazy(upload_error)?;
+        let (_id, mut destination) = object_store
             .put_multipart(&target_path)
             .await
             .into_report()
-            .change_context(Error::ReadWriteObjectStore)
-            .attach_printable_lazy(|| {
-                format!("failed to write multipart upload to path {}", target_path)
-            })?;
-        tokio::io::copy(&mut local_file, &mut writer)
+            .change_context_lazy(upload_error)?;
+        tokio::io::copy(&mut source, &mut destination)
             .await
             .into_report()
-            .change_context(Error::Internal)?;
-        writer
+            .change_context_lazy(upload_error)?;
+        destination
             .shutdown()
             .await
             .into_report()
-            .change_context(Error::Internal)?;
+            .change_context_lazy(upload_error)?;
+        Ok(())
+    }
+
+    /// Download the given object to the given local file path.
+    pub async fn download(
+        &self,
+        source_url: ObjectStoreUrl,
+        destination_path: &path::Path,
+    ) -> error_stack::Result<(), Error> {
+        let path = source_url.path()?;
+        let object_store = self.object_store(&source_url)?;
+
+        let download_error = || Error::DownloadingObject {
+            from: source_url.clone(),
+            to: destination_path.to_owned(),
+        };
+        let stream = object_store
+            .get(&path)
+            .await
+            .into_report()
+            .change_context_lazy(download_error)?
+            .into_stream();
+        let mut destination = tokio::fs::File::create(destination_path)
+            .await
+            .into_report()
+            .change_context_lazy(download_error)?;
+        let mut source = tokio_util::io::StreamReader::new(stream);
+        tokio::io::copy(&mut source, &mut destination)
+            .await
+            .into_report()
+            .change_context_lazy(download_error)?;
         Ok(())
     }
 }
@@ -85,23 +118,19 @@ pub enum Error {
     ObjectStore,
     #[display(fmt = "invalid URL '{_0}'")]
     InvalidUrl(String),
-    #[display(fmt = "missing host in URL '{_0}'")]
-    UrlMissingHost(Url),
-    #[display(fmt = "unsupported host '{}' in URL '{_0}", "_0.host().unwrap()")]
-    UrlUnsupportedHost(Url),
-    #[display(
-        fmt = "unsupported scheme '{}' in URL '{_0}'; expected one of 'file' or 's3'",
-        "_0.scheme()"
-    )]
-    UrlUnsupportedScheme(Url),
-    #[display(fmt = "invalid path '{}' in URL '{_0}'", "_0.path()")]
-    UrlInvalidPath(Url),
+    #[display(fmt = "invalid object stroe")]
+    InvalidObjectStore,
     #[display(fmt = "error creating object store")]
     CreatingObjectStore,
     #[display(fmt = "downloading object from '{from}' to '{}'", "to.display()")]
     DownloadingObject {
         from: ObjectStoreUrl,
         to: path::PathBuf,
+    },
+    #[display(fmt = "uploading object from '{}' to '{to}'", "from.display()")]
+    UploadingObject {
+        from: path::PathBuf,
+        to: ObjectStoreUrl,
     },
     #[display(fmt = "internal error")]
     Internal,
@@ -148,10 +177,9 @@ fn create_object_store(key: &ObjectStoreKey) -> error_stack::Result<Arc<dyn Obje
 mod tests {
     use std::str::FromStr;
 
+    use crate::stores::object_store_key::ObjectStoreKey;
     use crate::stores::ObjectStoreUrl;
-    use crate::stores::{
-        object_store_url::ObjectStoreKey, object_stores::create_object_store, ObjectStoreRegistry,
-    };
+    use crate::stores::{registry::create_object_store, ObjectStoreRegistry};
 
     #[test]
     fn test_create_object_store_local() {
@@ -192,7 +220,7 @@ mod tests {
         let object_store_registry = ObjectStoreRegistry::new();
         let key = ObjectStoreKey::Local;
         let url = ObjectStoreUrl::from_str("file:///foo").unwrap();
-        assert_eq!(key, url.key().unwrap());
+        assert_eq!(key, ObjectStoreKey::from_url(url.url()).unwrap());
 
         // Verify there is no object store for local first
         assert!(!object_store_registry.object_stores.contains_key(&key));


### PR DESCRIPTION
Move `upload` and `download` to the root `ObjectStoreRegistry`.

Move `object_store_key` to a separate file and make that an implementation detail.

This is part of cleanup after most of #465.