### PR TITLE
lint: Run `clippy --fix`

### DIFF
--- a/crates/sparrow-compiler/src/dfg/analysis.rs
+++ b/crates/sparrow-compiler/src/dfg/analysis.rs
@@ -335,7 +335,7 @@ mod tests {
             children: Vec::new(),
         };
 
-        let mut analysis = DfgAnalysis::default();
+        let mut analysis = DfgAnalysis;
         let merge_result = analysis.merge(&mut a, b);
         assert!(!merge_result.0);
         assert!(!merge_result.1);
@@ -370,7 +370,7 @@ mod tests {
             children: Vec::new(),
         };
 
-        let mut analysis = DfgAnalysis::default();
+        let mut analysis = DfgAnalysis;
         let merge_result = analysis.merge(&mut a, b);
         assert!(!merge_result.0);
         assert!(merge_result.1);
@@ -405,7 +405,7 @@ mod tests {
             children: Vec::new(),
         };
 
-        let mut analysis = DfgAnalysis::default();
+        let mut analysis = DfgAnalysis;
         let merge_result = analysis.merge(&mut a, b);
         assert!(merge_result.0);
         assert!(!merge_result.1);
@@ -441,7 +441,7 @@ mod tests {
             children: Vec::new(),
         };
 
-        let mut analysis = DfgAnalysis::default();
+        let mut analysis = DfgAnalysis;
         let merge_result = analysis.merge(&mut a, b);
         assert!(merge_result.0);
         assert!(!merge_result.1);

--- a/crates/sparrow-compiler/src/functions/function.rs
+++ b/crates/sparrow-compiler/src/functions/function.rs
@@ -38,27 +38,27 @@ impl<'building> FunctionBuilder<'building> {
         Self(instruction)
     }
 
-    pub fn set_internal(mut self) -> Self {
+    pub fn set_internal(self) -> Self {
         self.0.internal = true;
         self
     }
 
-    pub fn with_implementation(mut self, implementation: Implementation) -> Self {
+    pub fn with_implementation(self, implementation: Implementation) -> Self {
         self.0.implementation = implementation;
         self
     }
 
-    pub fn with_is_new(mut self, is_new: Implementation) -> Self {
+    pub fn with_is_new(self, is_new: Implementation) -> Self {
         self.0.is_new = is_new;
         self
     }
 
-    pub fn with_time_domain_check(mut self, time_domain_check: TimeDomainCheck) -> Self {
+    pub fn with_time_domain_check(self, time_domain_check: TimeDomainCheck) -> Self {
         self.0.time_domain_check = time_domain_check;
         self
     }
 
-    pub fn with_dfg_signature(mut self, signature_str: &'static str) -> Self {
+    pub fn with_dfg_signature(self, signature_str: &'static str) -> Self {
         let signature =
             Signature::try_from_str(FeatureSetPart::Function(signature_str), signature_str)
                 .unwrap_or_else(|e| panic!("Failed to parse signature '{signature_str}': {e:?}"));

--- a/crates/sparrow-instructions/benches/sparrow_instructions_benches/primitive_accum_token_bench.rs
+++ b/crates/sparrow-instructions/benches/sparrow_instructions_benches/primitive_accum_token_bench.rs
@@ -9,7 +9,7 @@ fn benchmark_serialize(vec: &[i64]) {
 }
 
 fn serialize_unsafe(vec: &[i64]) -> &[u8] {
-    let len = size_of::<i64>() * vec.len();
+    let len = std::mem::size_of_val(vec);
     // SAFETY: `ptr` has valid alignment (came from a vec) and contains `len` bytes.
     unsafe {
         let ptr = vec.as_ptr();

--- a/crates/sparrow-instructions/src/evaluators/aggregation/two_stacks.rs
+++ b/crates/sparrow-instructions/src/evaluators/aggregation/two_stacks.rs
@@ -123,7 +123,7 @@ impl<AggF: AggFn> TwoStacks<AggF> {
         // Each item should be the sum of its accumulator and the cumulative
         // values below it.
         let mut accum = AggF::zero();
-        for mut outgoing in &mut self.outgoing {
+        for outgoing in &mut self.outgoing {
             AggF::merge(&mut accum, &outgoing.accum);
             outgoing.cumulative = accum.clone();
         }

--- a/crates/sparrow-instructions/src/evaluators/comparison.rs
+++ b/crates/sparrow-instructions/src/evaluators/comparison.rs
@@ -47,7 +47,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -92,7 +92,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -133,7 +133,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -178,7 +178,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -219,7 +219,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -264,7 +264,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -305,7 +305,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -350,7 +350,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }

--- a/crates/sparrow-instructions/src/evaluators/equality.rs
+++ b/crates/sparrow-instructions/src/evaluators/equality.rs
@@ -139,7 +139,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -298,7 +298,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }

--- a/crates/sparrow-instructions/src/evaluators/math.rs
+++ b/crates/sparrow-instructions/src/evaluators/math.rs
@@ -54,7 +54,7 @@ where
         let input = info.unpack_argument()?;
         Ok(Box::new(Self {
             input,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -88,7 +88,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -122,7 +122,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -156,7 +156,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -214,7 +214,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }

--- a/crates/sparrow-instructions/src/evaluators/math/clamp.rs
+++ b/crates/sparrow-instructions/src/evaluators/math/clamp.rs
@@ -25,7 +25,7 @@ impl<T: ArrowNumericType> EvaluatorFactory for ClampEvaluator<T> {
             input,
             min,
             max,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }

--- a/crates/sparrow-instructions/src/evaluators/math/exp.rs
+++ b/crates/sparrow-instructions/src/evaluators/math/exp.rs
@@ -39,7 +39,7 @@ where
         let input = info.unpack_argument()?;
         Ok(Box::new(Self {
             input,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }

--- a/crates/sparrow-instructions/src/evaluators/math/min_max.rs
+++ b/crates/sparrow-instructions/src/evaluators/math/min_max.rs
@@ -25,7 +25,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }
@@ -59,7 +59,7 @@ where
         Ok(Box::new(Self {
             lhs,
             rhs,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }

--- a/crates/sparrow-instructions/src/evaluators/math/powf.rs
+++ b/crates/sparrow-instructions/src/evaluators/math/powf.rs
@@ -61,7 +61,7 @@ where
         Ok(Box::new(Self {
             base,
             exp,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }))
     }
 }

--- a/crates/sparrow-runtime/src/execute/operation/spread.rs
+++ b/crates/sparrow-runtime/src/execute/operation/spread.rs
@@ -489,7 +489,7 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for UnlatchedPrimitiveSpread<T> {
 impl<T: ArrowPrimitiveType> UnlatchedPrimitiveSpread<T> {
     fn new() -> Self {
         Self {
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }


### PR DESCRIPTION
This fixes warnings appearing in the new version of Rust.