### PR TITLE
build: use statically linked libssl

### DIFF
--- a/.github/workflows/release_engine.yml
+++ b/.github/workflows/release_engine.yml
@@ -374,6 +374,7 @@ jobs:
       
       - name: Build and push Docker images for Jupyter Beta
         uses: docker/build-push-action@v4
+        if: startsWith(github.ref, 'refs/tags/engine@v') && contains(github.ref, 'beta')
         with:
           context: .
           platforms: linux/amd64, linux/arm64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.26.0+1.1.1u"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,6 +2902,7 @@ checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ prost-wkt-build = "0.4.1"
 prost-wkt-types = "0.4.1"
 pulsar = { version = "5.1.0", default-features = false, features = ["async-std-runtime", "tokio-runtime", "lz4"] }
 rand = "0.8.5"
-reqwest = "0.11.14"
+reqwest = { version = "0.11.14", features = ["native-tls-vendored"] }
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde_json = "1.0.95"
 serde_yaml = "0.9.19"


### PR DESCRIPTION
We build our binaries on ubuntu:20 which uses libssl1.1 (through our direct dependency of `reqwest`). Libssl is dynamically linked and with systems moving to ubuntu:22 that has libssl3.0 our binary breaks. An example is Google's Collab. 

We also build multiplatform linux docker image using `cross-rs`. `cross-rs` currently builds for ubuntu:20 on their `master` branch and there is currently an open PR (https://github.com/cross-rs/cross/pull/973) to move to ubuntu:22. 

The proposed solution with this PR is to enable the feature on `reqwest` that builds the libssl crate (and the libssl library) statically in the sparrow binaries rather than relying on dynamic linking to pick the system's libssl library. 

We are *not* moving our CI to use ubuntu:22 until there we have a solution for building multiarch images on ubuntu:22 (through `cross-rs` or otherwise). Otherwise, if we move to ubuntu:22 today with out any other changes our docker image will break on linux on arm (anyone on a Mac with an M chip running a docker container). 




1. sparrow depends on `reqwest` which brings in libssl. 
2. added an `if` condition on the release CI that we missed


I verified that the binaries 

Before: 
```
❯ ldd sparrow-main
	linux-vdso.so.1 (0x00007fff56643000)
	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007f3387ee8000)
	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f3383e00000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f3383a00000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f3387ec8000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f3384321000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f3383c1f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f3387fa4000)

```


After 

```
❯ ldd sparrow-main
        linux-vdso.so.1 (0x00007ffc7d3f2000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f3989800000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f398d9aa000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f3989b21000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f398961f000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f398d9dd000)
```


The final `release` binary size increases by 2MB 

Before:
 
```
❯ ls -lh sparrow-main
-rwxr-xr-x 2 therapon therapon 85M Jul 24 13:09 sparrow-main

```

After

```
❯ ls -lh sparrow-main             
-rwxr-xr-x 2 therapon therapon 87M Jul 24 13:06 sparrow-main

```