### PR TITLE
ref: Expose a QueryBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,6 +4328,7 @@ dependencies = [
  "ahash 0.8.3",
  "anyhow",
  "arrow",
+ "arrow-schema",
  "bit-set",
  "chrono",
  "clap",

--- a/crates/sparrow-compiler/Cargo.toml
+++ b/crates/sparrow-compiler/Cargo.toml
@@ -13,6 +13,7 @@ Compiler from Fenl syntax to Sparrow execution plans.
 ahash.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
+arrow-schema.workspace = true
 bit-set.workspace = true
 chrono.workspace = true
 const_format.workspace = true

--- a/crates/sparrow-compiler/src/dfg.rs
+++ b/crates/sparrow-compiler/src/dfg.rs
@@ -504,6 +504,15 @@ impl Dfg {
         self.graph[id].data.literal_opt()
     }
 
+    /// Returns `Some(str)` if the ID is a string literal in the graph.
+    pub fn string_literal(&self, id: Id) -> Option<&str> {
+        self.literal(id).and_then(|s| match s {
+            ScalarValue::Utf8(s) => s.as_ref().map(|s| s.as_str()),
+            ScalarValue::LargeUtf8(s) => s.as_ref().map(|s| s.as_str()),
+            _ => None,
+        })
+    }
+
     /// Returns the ID of the operation node defining the domain of `id`.
     pub fn operation(&self, id: Id) -> Id {
         self.graph[id].data.operation(id)

--- a/crates/sparrow-compiler/src/diagnostics/feature_set_parts.rs
+++ b/crates/sparrow-compiler/src/diagnostics/feature_set_parts.rs
@@ -33,6 +33,7 @@ pub enum PartName<'a> {
     Formula(&'a str),
     /// Return the part name for the query string.
     Query,
+    Builder,
 }
 
 impl<'a> std::fmt::Display for PartName<'a> {
@@ -44,6 +45,7 @@ impl<'a> std::fmt::Display for PartName<'a> {
             PartName::Label(name) => write!(f, "'{name}'"),
             PartName::Formula(name) => write!(f, "'Formula: {name}'"),
             PartName::Query => write!(f, "Query"),
+            PartName::Builder => write!(f, "Builder"),
         }
     }
 }
@@ -112,6 +114,7 @@ impl<'a> Files<'a> for FeatureSetParts<'a> {
                 }
             }
             FeatureSetPart::Query => Ok(PartName::Query),
+            FeatureSetPart::Builder => Ok(PartName::Builder),
         }
     }
 
@@ -127,6 +130,7 @@ impl<'a> Files<'a> for FeatureSetParts<'a> {
                 .ok_or(Error::FileMissing)?
                 .formula),
             FeatureSetPart::Query => Ok(&self.feature_set.query),
+            FeatureSetPart::Builder => Ok("builder"),
         }
     }
 
@@ -140,6 +144,7 @@ impl<'a> Files<'a> for FeatureSetParts<'a> {
                 .get(index as usize)
                 .ok_or(Error::FileMissing)?,
             FeatureSetPart::Query => &self.query_line_starts,
+            FeatureSetPart::Builder => return Ok(0),
         };
 
         Ok(line_starts
@@ -163,6 +168,7 @@ impl<'a> Files<'a> for FeatureSetParts<'a> {
                 .get(index as usize)
                 .ok_or(Error::FileMissing)?,
             FeatureSetPart::Query => &self.query_line_starts,
+            FeatureSetPart::Builder => return Ok(0.."builder".len()),
         };
 
         self.line_range_helper(id, line_starts, line_index)

--- a/crates/sparrow-compiler/src/frontend/resolve_arguments.rs
+++ b/crates/sparrow-compiler/src/frontend/resolve_arguments.rs
@@ -9,7 +9,7 @@ use static_init::dynamic;
 use crate::{DiagnosticBuilder, DiagnosticCode};
 
 #[dynamic]
-static FIELD_REF_ARGUMENTS: [Located<String>; 1] = [Located::internal_string("record")];
+pub(crate) static FIELD_REF_ARGUMENTS: [Located<String>; 1] = [Located::internal_string("record")];
 
 #[dynamic]
 static PIPE_ARGUMENTS: [Located<String>; 2] = [

--- a/crates/sparrow-compiler/src/lib.rs
+++ b/crates/sparrow-compiler/src/lib.rs
@@ -42,6 +42,7 @@ mod functions;
 mod nearest_matches;
 mod options;
 mod plan;
+pub mod query_builder;
 mod time_domain;
 mod types;
 

--- a/crates/sparrow-compiler/src/query_builder.rs
+++ b/crates/sparrow-compiler/src/query_builder.rs
@@ -1,0 +1,235 @@
+use std::borrow::Cow;
+
+use crate::dfg::Dfg;
+use crate::resolve_arguments::FIELD_REF_ARGUMENTS;
+use crate::{AstDfgRef, DataContext, DiagnosticCollector};
+use arrow_schema::SchemaRef;
+use error_stack::{IntoReportCompat, ResultExt};
+use itertools::Itertools;
+use smallvec::smallvec;
+use sparrow_api::kaskada::v1alpha::{ComputeTable, FeatureSet, TableConfig, TableMetadata};
+use sparrow_syntax::{ExprOp, LiteralValue, Located, Location, Resolved};
+use uuid::Uuid;
+
+/// Kaskada query builder.
+#[derive(Default)]
+pub struct QueryBuilder {
+    data_context: DataContext,
+    dfg: Dfg,
+}
+
+#[derive(derive_more::Display, Debug)]
+pub enum Error {
+    #[display(fmt = "failed to create table '{name}'")]
+    CreateTable { name: String },
+    #[display(fmt = "failed to encode schema for table '{_0}'")]
+    SchemaForTable(String),
+    #[display(fmt = "invalid expression")]
+    Invalid,
+    #[display(fmt = "no function named '{name}': nearest matches are {nearest:?}")]
+    NoSuchFunction { name: String, nearest: Vec<String> },
+    #[display(fmt = "errors during construction")]
+    Errors,
+}
+
+impl error_stack::Context for Error {}
+
+pub enum Literal {
+    StringLiteral(String),
+    Int64Literal(i64),
+    UInt64Literal(u64),
+    Float64Literal(f64),
+}
+
+impl QueryBuilder {
+    pub fn add_table(
+        &mut self,
+        name: &str,
+        schema: SchemaRef,
+        time_column_name: &str,
+        subsort_column_name: Option<&str>,
+        key_column_name: &str,
+        grouping_name: Option<&str>,
+    ) -> error_stack::Result<AstDfgRef, Error> {
+        let uuid = Uuid::new_v4();
+        let schema_proto: sparrow_api::kaskada::v1alpha::Schema =
+            error_stack::IntoReport::into_report(schema.as_ref().try_into())
+                .change_context_lazy(|| Error::SchemaForTable(name.to_owned()))?;
+        let table = ComputeTable {
+            config: Some(TableConfig {
+                name: name.to_owned(),
+                uuid: uuid.to_string(),
+                time_column_name: time_column_name.to_owned(),
+                subsort_column_name: subsort_column_name.map(|s| s.to_owned()),
+                group_column_name: key_column_name.to_owned(),
+                grouping: grouping_name.unwrap_or("").to_owned(),
+                source: None,
+            }),
+            metadata: Some(TableMetadata {
+                schema: Some(schema_proto),
+                file_count: 0,
+            }),
+            file_sets: vec![],
+        };
+
+        let table_info = self
+            .data_context
+            .add_table(table)
+            .into_report()
+            .change_context_lazy(|| Error::CreateTable {
+                name: name.to_owned(),
+            })?;
+        table_info
+            .dfg_node(&mut self.dfg)
+            .into_report()
+            .change_context(Error::CreateTable {
+                name: name.to_owned(),
+            })
+    }
+
+    fn add_to_dfg(
+        &mut self,
+        op: ExprOp,
+        args: Resolved<Located<AstDfgRef>>,
+    ) -> error_stack::Result<AstDfgRef, Error> {
+        let feature_set = FeatureSet::default();
+        let mut diagnostics = DiagnosticCollector::new(&feature_set);
+        let result = crate::add_to_dfg(
+            &mut self.data_context,
+            &mut self.dfg,
+            &mut diagnostics,
+            &op,
+            args,
+            None,
+        )
+        .into_report()
+        .change_context(Error::Invalid)?;
+
+        if diagnostics.num_errors() > 0 {
+            Err(Error::Errors)?
+        } else {
+            Ok(result)
+        }
+    }
+
+    pub fn add_literal(&mut self, literal: Literal) -> error_stack::Result<AstDfgRef, Error> {
+        let literal_value = match literal {
+            Literal::StringLiteral(s) => LiteralValue::String(s),
+            Literal::Int64Literal(n) => LiteralValue::Number(n.to_string()),
+            Literal::UInt64Literal(n) => LiteralValue::Number(n.to_string()),
+            Literal::Float64Literal(n) => LiteralValue::Number(n.to_string()),
+        };
+        self.add_to_dfg(
+            ExprOp::Literal(Located::builder(literal_value)),
+            Resolved::default(),
+        )
+    }
+
+    pub fn add_expr(
+        &mut self,
+        function: &str,
+        args: &[AstDfgRef],
+    ) -> error_stack::Result<AstDfgRef, Error> {
+        let (op, args) = match function {
+            "fieldref" => {
+                assert_eq!(args.len(), 2);
+                let (base, name) = args.iter().cloned().collect_tuple().unwrap();
+
+                let name = self.dfg.string_literal(name.value()).expect("literal name");
+
+                let op = ExprOp::FieldRef(Located::builder(name.to_owned()), Location::builder());
+                let args = Resolved::new(
+                    Cow::Borrowed(&*FIELD_REF_ARGUMENTS),
+                    smallvec![Located::builder(base)],
+                    false,
+                );
+                (op, args)
+            }
+            "make_record" => {
+                todo!()
+            }
+            "remove_fields" => {
+                todo!()
+            }
+            "select_fields" => {
+                todo!()
+            }
+            "extend_record" => {
+                todo!()
+            }
+            "cast" => {
+                todo!()
+            }
+            function => {
+                let op = ExprOp::Call(Located::builder(function.to_owned()));
+
+                let function = match crate::get_function(function) {
+                    Ok(function) => function,
+                    Err(matches) => {
+                        error_stack::bail!(Error::NoSuchFunction {
+                            name: function.to_owned(),
+                            nearest: matches
+                                .into_iter()
+                                .map(|m| m.to_owned())
+                                .collect::<Vec<_>>()
+                        });
+                    }
+                };
+
+                // TODO: Make this a proper error (not an assertion).
+                function.signature().assert_valid_argument_count(args.len());
+
+                let has_vararg = args.len() > function.signature().arg_names().len();
+                let args = Resolved::new(
+                    function.signature().arg_names().into(),
+                    args.iter().cloned().map(Located::builder).collect(),
+                    has_vararg,
+                );
+                (op, args)
+            }
+        };
+
+        self.add_to_dfg(op, args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_schema::{DataType, Field, Schema, TimeUnit};
+    use sparrow_syntax::FenlType;
+
+    use super::*;
+
+    #[test]
+    fn basic_builder_test() {
+        let mut query_builder = QueryBuilder::default();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "time",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("key", DataType::UInt64, false),
+            Field::new("a", DataType::UInt64, true),
+            Field::new("b", DataType::Int64, true),
+        ]));
+        let table = query_builder
+            .add_table("table", schema, "time", None, "key", Some("user"))
+            .unwrap();
+
+        let field_name = query_builder
+            .add_literal(Literal::StringLiteral("a".to_owned()))
+            .unwrap();
+        let field_ref = query_builder
+            .add_expr("fieldref", &[table, field_name])
+            .unwrap();
+
+        assert_eq!(
+            field_ref.value_type(),
+            &FenlType::Concrete(DataType::UInt64)
+        );
+    }
+}

--- a/crates/sparrow-runtime/src/read/table_reader.rs
+++ b/crates/sparrow-runtime/src/read/table_reader.rs
@@ -661,7 +661,7 @@ mod tests {
         let mut data_context = DataContext::default();
         let schema =
             sparrow_api::kaskada::v1alpha::Schema::try_from(TABLE_SCHEMA.as_ref()).unwrap();
-        let table_id = data_context
+        let table_info = data_context
             .add_table(ComputeTable {
                 config: Some(CONFIG.clone()),
                 metadata: Some(TableMetadata {
@@ -674,7 +674,6 @@ mod tests {
                 }],
             })
             .unwrap();
-        let table_info = data_context.table_info(table_id).unwrap();
 
         let prepared_files =
             select_prepared_files(table_info, &None, Some(max_event_in_snapshot)).unwrap();
@@ -719,7 +718,7 @@ mod tests {
         let mut data_context = DataContext::default();
         let schema =
             sparrow_api::kaskada::v1alpha::Schema::try_from(TABLE_SCHEMA.as_ref()).unwrap();
-        let table_id = data_context
+        let table_info = data_context
             .add_table(ComputeTable {
                 config: Some(CONFIG.clone()),
                 metadata: Some(TableMetadata {
@@ -732,7 +731,6 @@ mod tests {
                 }],
             })
             .unwrap();
-        let table_info = data_context.table_info(table_id).unwrap();
 
         let upper_bound_opt = if let Some(ts) = max_event_time {
             NaiveDateTime::from_timestamp_opt(ts.seconds, ts.nanos as u32)

--- a/crates/sparrow-syntax/src/syntax/arguments.rs
+++ b/crates/sparrow-syntax/src/syntax/arguments.rs
@@ -462,6 +462,16 @@ pub struct Resolved<T> {
     pub has_vararg: bool,
 }
 
+impl<T> Default for Resolved<T> {
+    fn default() -> Self {
+        Self {
+            names: Default::default(),
+            values: Default::default(),
+            has_vararg: Default::default(),
+        }
+    }
+}
+
 impl<T: std::fmt::Debug> Resolved<T> {
     pub fn empty() -> Self {
         Self {

--- a/crates/sparrow-syntax/src/syntax/expr.rs
+++ b/crates/sparrow-syntax/src/syntax/expr.rs
@@ -25,6 +25,8 @@ pub enum FeatureSetPart {
     Formula(u32),
     /// The query.
     Query,
+    /// Code coming from python.
+    Builder,
 }
 
 /// The location of part of an expression in the original source.
@@ -44,6 +46,10 @@ pub struct Location {
 impl Location {
     pub fn new(part: FeatureSetPart, start: usize, end: usize) -> Self {
         Self { part, start, end }
+    }
+
+    pub fn builder() -> Self {
+        Location::new(FeatureSetPart::Builder, 0, "builder".len())
     }
 
     pub fn internal_str(value: &'static str) -> Self {
@@ -107,6 +113,13 @@ impl<T> Located<T> {
         Self { value, location }
     }
 
+    pub fn builder(value: T) -> Self {
+        Self {
+            value,
+            location: Location::builder(),
+        }
+    }
+
     pub fn inner(&self) -> &T {
         &self.value
     }
@@ -132,6 +145,13 @@ impl<T> Located<T> {
             value: f(self.value),
             location: self.location,
         }
+    }
+
+    pub fn try_map<T2, E>(self, f: impl FnOnce(T) -> Result<T2, E>) -> Result<Located<T2>, E> {
+        Ok(Located {
+            value: f(self.value)?,
+            location: self.location,
+        })
     }
 
     pub fn with_value<T2>(&self, value: T2) -> Located<T2> {


### PR DESCRIPTION
This is pretty ugly -- it has to do create a lot of fake locations and create enums (like `ExprOp`) just to call into the existing AST -> DFG compilation. We should definitely clean this up if we continue down the path of using builders.