### PR TITLE
bug: fix default schema in inference for map/list

### DIFF
--- a/crates/sparrow-main/tests/e2e/map_tests.rs
+++ b/crates/sparrow-main/tests/e2e/map_tests.rs
@@ -230,3 +230,35 @@ async fn test_incompatible_key_types() {
           - ""
     "###);
 }
+
+#[tokio::test]
+async fn test_using_map_in_index_fails() {
+    insta::assert_yaml_snapshot!(QueryFixture::new("{ f1: Input.i64_to_i64 | index(0) }")
+        .run_to_csv(&map_data_fixture().await).await.unwrap_err(), @r###"
+    ---
+    code: Client specified an invalid argument
+    message: 1 errors in Fenl statements; see diagnostics
+    fenl_diagnostics:
+      - severity: error
+        code: E0010
+        message: Invalid argument type(s)
+        formatted:
+          - "error[E0010]: Invalid argument type(s)"
+          - "  --> Query:1:26"
+          - "  |"
+          - "1 | { f1: Input.i64_to_i64 | index(0) }"
+          - "  |                          ^^^^^ Invalid types for parameter 'list' in call to 'index'"
+          - "  |"
+          - "  --> internal:1:1"
+          - "  |"
+          - 1 | $input
+          - "  | ------ Actual type: map<i64, i64>"
+          - "  |"
+          - "  --> built-in signature 'index<T: any>(i: i64, list: list<T>) -> T':1:29"
+          - "  |"
+          - "1 | index<T: any>(i: i64, list: list<T>) -> T"
+          - "  |                             ------- Expected type: list<T>"
+          - ""
+          - ""
+    "###);
+}


### PR DESCRIPTION
Fixes the default schema for the `map` and `list` types in inference. This isn't a good solution, as there's no guarantee that Arrow doesn't change this behavior in the future. Ideally, we can figure out how to plumb the user map type information through inference. But, it's difficult because functions that produce `map` or `list` types need an arbitrary naming/nullability that we define. 

Closes #576 