### PR TITLE
ref: Cleanup sources in Python

### DIFF
--- a/sparrow-py/.darglint
+++ b/sparrow-py/.darglint
@@ -1,3 +1,4 @@
 [darglint]
 strictness = short
 docstring_style=numpy
+ignore_regex=^(test)?_(.*),

--- a/sparrow-py/.flake8
+++ b/sparrow-py/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 select = B,B9,C,D,DAR,E,F,N,RST,W
 ignore = E203,E501,RST201,RST203,RST301,W503
-max-line-length = 80
+max-line-length = 100
 max-complexity = 10
 docstring-convention = numpy
 rst-roles = class,const,func,meth,mod,ref

--- a/sparrow-py/noxfile.py
+++ b/sparrow-py/noxfile.py
@@ -42,7 +42,7 @@ def install_self(session: Session) -> None:
 
 @session(python=python_versions[0])
 def check_lint(session: Session) -> None:
-    """Lint using pre-commit."""
+    """Lint."""
     args = session.posargs or ["pysrc", "pytests", "docs/conf.py"]
     session.install(
         "black",
@@ -53,8 +53,6 @@ def check_lint(session: Session) -> None:
         "flake8-rst-docstrings",
         "isort",
         "pep8-naming",
-        "pre-commit",
-        "pre-commit-hooks",
         "pyupgrade",
     )
     session.run
@@ -73,8 +71,6 @@ def fix_lint(session: Session) -> None:
         "black",
         "isort",
         "pep8-naming",
-        "pre-commit",
-        "pre-commit-hooks",
         "pyupgrade",
     )
     session.run

--- a/sparrow-py/pysrc/sparrow_py/__init__.py
+++ b/sparrow-py/pysrc/sparrow_py/__init__.py
@@ -1,7 +1,6 @@
 """Kaskada query builder and local executon engine."""
 from .expr import Expr
 from .session import init_session
-from .table import Table
 
 
-__all__ = ["Expr", "init_session", "Table"]
+__all__ = ["Expr", "init_session"]

--- a/sparrow-py/pysrc/sparrow_py/session.py
+++ b/sparrow-py/pysrc/sparrow_py/session.py
@@ -1,7 +1,12 @@
-from sparrow_py import _ffi
+"""Defines methods for initializing the Kaskada session."""
+
 from typing import Optional
 
+from sparrow_py import _ffi
+
+
 _SESSION: Optional[_ffi.Session] = None
+
 
 def init_session() -> None:
     """
@@ -9,9 +14,6 @@ def init_session() -> None:
 
     This must only be called once per session. It must be called before
     any other Kaskada functions are called.
-
-    Parameters
-    ----------
 
     Raises
     ------
@@ -23,9 +25,14 @@ def init_session() -> None:
         raise RuntimeError("Session has already been initialized")
     _SESSION = _ffi.Session()
 
+
 def _get_session() -> _ffi.Session:
     """
     Assert that the session has been initialized.
+
+    Returns
+    -------
+    The FFI session handle.
 
     Raises
     ------

--- a/sparrow-py/pysrc/sparrow_py/sources/__init__.py
+++ b/sparrow-py/pysrc/sparrow_py/sources/__init__.py
@@ -1,0 +1,7 @@
+"""Sources of data for Kaskada queries."""
+from .arrow import ArrowSource
+from .arrow import CsvSource
+from .source import Source
+
+
+__all__ = ["Source", "ArrowSource", "CsvSource"]

--- a/sparrow-py/pysrc/sparrow_py/sources/arrow.py
+++ b/sparrow-py/pysrc/sparrow_py/sources/arrow.py
@@ -1,0 +1,59 @@
+"""Provide sources based on PyArrow, including Pandas and CSV."""
+from io import StringIO
+from typing import Optional
+from typing import Union
+
+import pandas as pd
+import pyarrow as pa
+
+from .source import Source
+
+
+class ArrowSource(Source):
+    """A source reading data batches from Arrow or Pandas."""
+
+    def __init__(
+        self,
+        time_column_name: str,
+        key_column_name: str,
+        data: Union[pd.DataFrame, pa.RecordBatch],
+        subsort_column_name: Optional[str] = None,
+        grouping_name: Optional[str] = None,
+    ):
+        """Create a new source reading from Arrow or Pandas."""
+        if isinstance(data, pd.DataFrame):
+            schema = pa.Schema.from_pandas(data)
+
+            def fix_nullable(field: pa.Field) -> pa.Field:
+                if field.name in [
+                    time_column_name,
+                    key_column_name,
+                    subsort_column_name,
+                ]:
+                    return field.with_nullable(False)
+                else:
+                    return field
+
+            fields = [fix_nullable(f) for f in schema]
+            schema = pa.schema(fields)
+            data = pa.RecordBatch.from_pandas(data, schema)
+
+        super().__init__(
+            time_column_name,
+            key_column_name,
+            data.schema,
+            subsort_column_name,
+            grouping_name,
+        )
+
+        self._ffi_table.add_pyarrow(data)
+
+
+class CsvSource(ArrowSource):
+    """Source reading data from CSV via Pandas."""
+
+    def __init__(
+        self, time_column_name: str, key_column_name: str, csv_string: str, **kwargs
+    ) -> None:
+        content = pd.read_csv(StringIO(csv_string), dtype_backend="pyarrow", **kwargs)
+        super().__init__(time_column_name, key_column_name, content)

--- a/sparrow-py/pysrc/sparrow_py/sources/source.py
+++ b/sparrow-py/pysrc/sparrow_py/sources/source.py
@@ -1,16 +1,19 @@
+"""Provide the base-class for Kaskada sources."""
 from typing import Optional
 
-import pandas as pd
 import pyarrow as pa
 import sparrow_py._ffi as _ffi
 from sparrow_py.expr import Expr
 from sparrow_py.session import _get_session
 
+
 _TABLE_NUM: int = 0
 
-class Table(Expr):
-    """ "A table expression."""
 
+class Source(Expr):
+    """A source expression."""
+
+    # TODO: Clean-up naming on the FFI side.
     _ffi_table: _ffi.Table
 
     def __init__(
@@ -21,10 +24,10 @@ class Table(Expr):
         subsort_column_name: Optional[str] = None,
         grouping_name: Optional[str] = None,
     ):
-        """Create a new table expression."""
-        Table._validate_column(time_column_name, schema)
-        Table._validate_column(key_column_name, schema)
-        Table._validate_column(subsort_column_name, schema)
+        """Create a new source."""
+        Source._validate_column(time_column_name, schema)
+        Source._validate_column(key_column_name, schema)
+        Source._validate_column(subsort_column_name, schema)
 
         # Hack -- Sparrow currently requires tables be named.
         global _TABLE_NUM
@@ -44,13 +47,8 @@ class Table(Expr):
 
     @property
     def name(self) -> str:
-        """Get the current voltage."""
+        """Get the current table name."""
         return self._ffi_table.name
-
-    def add_data(self, df: pd.DataFrame) -> None:
-        """Add a dataframe to a table."""
-        pa_table = pa.RecordBatch.from_pandas(df)
-        self._ffi_table.add_pyarrow(pa_table)
 
     # TODO: Most of these checks exist in Sparrow. We should just surface
     # those errors more cleanly.
@@ -59,6 +57,6 @@ class Table(Expr):
         if field_name is not None:
             field = schema.field(field_name)
             if field is None:
-                raise KeyError(f"Column '{field_name}' does not exist")
+                raise KeyError(f"Column {field_name!r} does not exist")
             if field.nullable:
-                raise ValueError(f"Column: '{field_name}' must be non-nullable")
+                raise ValueError(f"Column: {field_name!r} must be non-nullable")

--- a/sparrow-py/pysrc/sparrow_py/udf.py
+++ b/sparrow-py/pysrc/sparrow_py/udf.py
@@ -1,3 +1,4 @@
+"""Functionality for calling Python UDFs from Kaskada."""
 import functools
 from typing import Callable
 
@@ -10,13 +11,31 @@ FuncType = Callable[..., pd.Series]
 
 
 class Udf(object):
+    """Class wrapping a UDF used in Kaskada."""
+
     def __init__(self, name, func: FuncType, signature: str) -> None:
+        """Create a UDF for a function returning a Pandas series.
+
+        Parameters
+        ----------
+        name : str
+            Name of the function being wrapped.
+
+        func : FuncType
+            The callable to wrap.
+
+        signature : str
+            The Kaskada function signature for this UDF. Will be used to check
+            types of calls to this function and propagate type information for
+            the rest of the query.
+        """
         functools.update_wrapper(self, func)
         self.name = name
         self.func = func
         self.signature = signature
 
     def run_pyarrow(self, result_type: pa.DataType, *args: pa.Array) -> pa.Array:
+        """Run the function producing the given result type."""
         # TODO: I believe this will return a series for simple arrays, and a
         # dataframe for struct arrays. We should explore how this handles
         # different types.
@@ -30,6 +49,8 @@ class Udf(object):
 
 
 def fenl_udf(name: str, signature: str):
+    """Decorate a function for use as a Kaskada UDF."""
+
     def decorator(func: FuncType):
         print(type(func))
         return Udf(name, func, signature)

--- a/sparrow-py/pytests/conftest.py
+++ b/sparrow-py/pytests/conftest.py
@@ -1,8 +1,9 @@
+"""PyTest configuration for Sparrow tests."""
 import pytest
 from sparrow_py import init_session
 
 
-@pytest.fixture(autouse = True, scope = "session")
+@pytest.fixture(autouse=True, scope="session")
 def session() -> None:
     """Automatically initialize the session for this PyTest session."""
     init_session()

--- a/sparrow-py/pytests/expr_test.py
+++ b/sparrow-py/pytests/expr_test.py
@@ -3,12 +3,12 @@ import sys
 
 import pyarrow as pa
 import pytest
-from sparrow_py import Table
 from sparrow_py import math
+from sparrow_py.sources import Source
 
 
-@pytest.fixture(scope = "module")
-def table1() -> Table:
+@pytest.fixture(scope="module")
+def source1() -> Source:
     """Create a table for testing."""
     schema = pa.schema(
         [
@@ -18,21 +18,21 @@ def table1() -> Table:
             pa.field("y", pa.int32()),
         ]
     )
-    return Table("time", "key", schema)
+    return Source("time", "key", schema)
 
 
-def test_field_ref(table1) -> None:
+def test_field_ref(source1) -> None:
     """Test for field references."""
-    field_ref_short = table1.x
+    field_ref_short = source1.x
     assert field_ref_short.data_type == pa.float64()
-    assert field_ref_short == table1.x
+    assert field_ref_short == source1.x
 
-    field_ref_long = table1["x"]
+    field_ref_long = source1["x"]
     assert field_ref_long.data_type == pa.float64()
     assert field_ref_short == field_ref_long
 
 
-def test_field_ref_no_such_field(table1) -> None:
+def test_field_ref_no_such_field(source1) -> None:
     """Test error when there is no such field."""
     with pytest.raises(AttributeError) as e:
         # This raises a "NoSuchAttribute" error.
@@ -41,53 +41,53 @@ def test_field_ref_no_such_field(table1) -> None:
         #
         # TODO: We should either surface the Sparrow error which suggests
         # possible field names, or improve the Python error.
-        table1.foo
+        source1.foo
     assert "Field 'foo' not found in 'time', 'key', 'x', 'y'" == str(e.value)
 
 
-def test_field_ref_not_a_struct(table1) -> None:
+def test_field_ref_not_a_struct(source1) -> None:
     """Test error when there the base is not a struct."""
     with pytest.raises(TypeError) as e:
-        table1.x.x
+        source1.x.x
     assert "Cannot access field 'x' on non-struct type 12" == str(e.value)
 
 
-def test_expr(table1) -> None:
+def test_expr(source1) -> None:
     """Test creating an expression node."""
-    x = table1.x
+    x = source1.x
     assert x + 1 == x + 1
 
 
-def test_expr_comparison(table1) -> None:
+def test_expr_comparison(source1) -> None:
     """Test basic comparisons."""
-    assert (table1.x > 1) == (table1.x > 1)
+    assert (source1.x > 1) == (source1.x > 1)
 
     # Python doesn't have a `__rgt__` (reverse gt) dunder method.
     # Instead, if the LHS doesn't support `gt` with the RHS, it tries
     # rhs `lt` lhs.
-    assert (1 < table1.x) == (table1.x > 1)
+    assert (1 < source1.x) == (source1.x > 1)
 
 
-def test_expr_pipe(table1) -> None:
+def test_expr_pipe(source1) -> None:
     """Test using `pipe` to create expressions."""
-    assert table1.x.pipe(math.add, 1) == math.add(table1.x, 1)
-    assert table1.x.pipe((math.add, "rhs"), 1) == math.add(1, rhs=table1.x)
+    assert source1.x.pipe(math.add, 1) == math.add(source1.x, 1)
+    assert source1.x.pipe((math.add, "rhs"), 1) == math.add(1, rhs=source1.x)
 
-    assert table1.x.pipe(math.gt, 1) == math.gt(table1.x, 1)
-    assert table1.x.pipe((math.gt, "rhs"), 1) == math.gt(1, rhs=table1.x)
+    assert source1.x.pipe(math.gt, 1) == math.gt(source1.x, 1)
+    assert source1.x.pipe((math.gt, "rhs"), 1) == math.gt(1, rhs=source1.x)
 
 
-def test_expr_arithmetic_types(table1) -> None:
+def test_expr_arithmetic_types(source1) -> None:
     """Test type inference and type errors of arithmetic expressions."""
-    assert math.eq(table1.x, 1).data_type == pa.bool_()
-    assert math.add(table1.x, 1).data_type == pa.float64()
-    assert (table1.x + table1.y).data_type == pa.float64()
+    assert math.eq(source1.x, 1).data_type == pa.bool_()
+    assert math.add(source1.x, 1).data_type == pa.float64()
+    assert (source1.x + source1.y).data_type == pa.float64()
 
     # TODO: This should raise a TypeError, but currently the Rust
     # code always raises a ValueError, so everything comes out
     # looking the same.
     with pytest.raises(ValueError) as e:
-        math.eq(table1.x, 1) + table1.y
+        math.eq(source1.x, 1) + source1.y
     assert "Incompatible argument types" in str(e)
     if sys.version_info >= (3, 11):
         assert "Arg[0]: Expr of type bool" in e.value.__notes__

--- a/sparrow-py/pytests/udf_test.py
+++ b/sparrow-py/pytests/udf_test.py
@@ -1,3 +1,5 @@
+"""Tests for using Python UDFs in Kaskada queries."""
+
 import pandas as pd
 import pyarrow as pa
 from sparrow_py._ffi import call_udf
@@ -7,6 +9,7 @@ from sparrow_py.udf import fenl_udf
 
 @fenl_udf("add", "add(x: number, y: number) -> number")
 def add(x: pd.Series, y: pd.Series) -> pd.Series:
+    """Add two numeric values together."""
     return x + y
 
 


### PR DESCRIPTION
Separate the different kinds of sources, so we have an `ArrowSource` for PyArrow and Pandas based data. Default to taking an initial batch in the constructor, so the schema can be inferred.