### PR TITLE
feat: Support aggregation functions in Python

### DIFF
--- a/crates/sparrow-compiler/src/dfg.rs
+++ b/crates/sparrow-compiler/src/dfg.rs
@@ -45,7 +45,7 @@ pub(super) use expr::DfgExpr;
 pub(crate) use pattern::*;
 use smallvec::smallvec;
 use tracing::{info, info_span};
-pub(crate) use useless_transforms::*;
+pub use useless_transforms::*;
 
 use crate::ast_to_dfg::AstDfg;
 use crate::dfg::language::DfgLang;
@@ -107,7 +107,7 @@ impl Default for Dfg {
 }
 
 impl Dfg {
-    pub(super) fn add_literal(&mut self, literal: impl Into<ScalarValue>) -> anyhow::Result<Id> {
+    pub fn add_literal(&mut self, literal: impl Into<ScalarValue>) -> anyhow::Result<Id> {
         let literal = literal.into();
         if let ScalarValue::Utf8(Some(literal)) = literal {
             self.add_string_literal(&literal)
@@ -253,7 +253,7 @@ impl Dfg {
                     );
                 }
 
-                // 2. The number of arguments should be correct.
+                // 2. The number of argflatten_uments should be correct.
                 match expr {
                     Expression::Literal(_) | Expression::LateBound(_) => {
                         anyhow::ensure!(

--- a/crates/sparrow-compiler/src/dfg/useless_transforms.rs
+++ b/crates/sparrow-compiler/src/dfg/useless_transforms.rs
@@ -13,7 +13,7 @@ use crate::dfg::{DfgExpr, StepKind};
 /// guaranteed that all such nodes are removed. This pass ensures
 /// that any later analysis of the DFG does not have to deal with
 /// useless transforms.
-pub(crate) fn remove_useless_transforms(expr: DfgExpr) -> anyhow::Result<DfgExpr> {
+pub fn remove_useless_transforms(expr: DfgExpr) -> anyhow::Result<DfgExpr> {
     let mut rewritten = DfgExpr::with_capacity(expr.len());
     let mut rewritten_ids = Vec::with_capacity(expr.len());
 

--- a/crates/sparrow-compiler/src/diagnostics/collector.rs
+++ b/crates/sparrow-compiler/src/diagnostics/collector.rs
@@ -29,7 +29,7 @@ impl<'a> std::fmt::Debug for DiagnosticCollector<'a> {
 #[derive(Clone, Debug)]
 pub struct CollectedDiagnostic {
     code: DiagnosticCode,
-    formatted: String,
+    pub formatted: String,
     pub message: String,
 }
 

--- a/crates/sparrow-compiler/src/lib.rs
+++ b/crates/sparrow-compiler/src/lib.rs
@@ -49,7 +49,7 @@ mod types;
 pub use ast_to_dfg::*;
 pub use compile::*;
 pub use data_context::*;
-pub use dfg::Dfg;
+pub use dfg::{remove_useless_transforms, Dfg};
 pub use diagnostics::*;
 pub use error::*;
 pub use frontend::*;

--- a/crates/sparrow-session/src/expr.rs
+++ b/crates/sparrow-session/src/expr.rs
@@ -25,8 +25,9 @@ impl Expr {
 }
 
 pub enum Literal {
-    StringLiteral(String),
-    Int64Literal(i64),
-    UInt64Literal(u64),
-    Float64Literal(f64),
+    Null,
+    String(String),
+    Int64(i64),
+    UInt64(u64),
+    Float64(f64),
 }

--- a/crates/sparrow-syntax/src/syntax/signature.rs
+++ b/crates/sparrow-syntax/src/syntax/signature.rs
@@ -160,7 +160,7 @@ impl Signature {
         } else {
             assert!(
                 num_args == self.parameters.names().len(),
-                "Expected operator '{:?}' to have exactly {:?} arguments, but was {:?}",
+                "Expected operator '{:?}' to have exactly {:?} arguments, but was {:?} ({self:?})",
                 self.name,
                 self.parameters.names().len(),
                 num_args,

--- a/sparrow-py/pysrc/sparrow_py/__init__.py
+++ b/sparrow-py/pysrc/sparrow_py/__init__.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from .expr import Expr
 from .session import init_session
+from ._windows import SinceWindow, SlidingWindow
 
 
 def record(fields: dict[str, Expr]) -> Expr:
@@ -13,4 +14,4 @@ def record(fields: dict[str, Expr]) -> Expr:
     return Expr.call("record", *args)
 
 
-__all__ = ["Expr", "init_session", "record"]
+__all__ = ["Expr", "init_session", "record", "SinceWindow", "SlidingWindow"]

--- a/sparrow-py/pysrc/sparrow_py/_windows.py
+++ b/sparrow-py/pysrc/sparrow_py/_windows.py
@@ -1,0 +1,19 @@
+import sparrow_py.expr as expr
+
+class Window(object):
+    """Base class for window functions."""
+    def __init__(self) -> None:
+        pass
+
+class SinceWindow(Window):
+    """Window since the last time a predicate was true."""
+    def __init__(self, predicate: "expr.Expr") -> None:
+        self._predicate = predicate
+
+class SlidingWindow(Window):
+    """
+    Sliding windows where the width is a multiple of some condition.
+    """
+    def __init__(self, duration: int, predicate: "expr.Expr") -> None:
+        self._duration = duration
+        self._predicate = predicate

--- a/sparrow-py/pysrc/sparrow_py/udf.py
+++ b/sparrow-py/pysrc/sparrow_py/udf.py
@@ -52,7 +52,6 @@ def fenl_udf(name: str, signature: str):
     """Decorate a function for use as a Kaskada UDF."""
 
     def decorator(func: FuncType):
-        print(type(func))
         return Udf(name, func, signature)
 
     return decorator

--- a/sparrow-py/pytests/aggregation_test.py
+++ b/sparrow-py/pytests/aggregation_test.py
@@ -1,0 +1,75 @@
+"""Tests for the Kaskada query builder."""
+import pytest
+import sparrow_py as s
+from sparrow_py.sources import CsvSource
+from sparrow_py import SlidingWindow, SinceWindow
+
+@pytest.fixture(scope = "module")
+def source() -> CsvSource:
+    """Create an empty table for testing."""
+    content = "\n".join(
+        [
+            "time,key,m,n",
+            "1996-12-19T16:39:57-08:00,A,5,10",
+            "1996-12-19T16:39:58-08:00,B,24,3",
+            "1996-12-19T16:39:59-08:00,A,17,6",
+            "1996-12-19T16:40:00-08:00,A,,9",
+            "1996-12-19T16:40:01-08:00,A,12,",
+            "1996-12-19T16:40:02-08:00,A,,",
+        ]
+    )
+    return CsvSource("time", "key", content)
+
+
+def test_sum_unwindowed(source) -> None:
+    """Test we can create a record."""
+    m = source["m"]
+    n = source["n"]
+    result = s.record(
+        {
+            "m": m,
+            "sum_m": m.sum(),
+            "n": n,
+            "sum_n": n.sum()
+        }
+    ).run_to_csv_string()
+
+    assert result == "\n".join(
+        [
+            "_time,_subsort,_key_hash,_key,m,sum_m,n,sum_n",
+            "1996-12-20 00:39:57,0,12960666915911099378,A,5.0,5,10.0,10",
+            "1996-12-20 00:39:58,1,2867199309159137213,B,24.0,24,3.0,3",
+            "1996-12-20 00:39:59,2,12960666915911099378,A,17.0,22,6.0,16",
+            "1996-12-20 00:40:00,3,12960666915911099378,A,,22,9.0,25",
+            "1996-12-20 00:40:01,4,12960666915911099378,A,12.0,34,,25",
+            "1996-12-20 00:40:02,5,12960666915911099378,A,,34,,25",
+            "",
+        ]
+    )
+
+def test_sum_windowed(source) -> None:
+    """Test we can create a record."""
+    m = source["m"]
+    n = source["n"]
+    result = s.record(
+        {
+            "m": m,
+            "sum_m": m.sum(window = SinceWindow(m > 20)),
+            "n": n,
+            "sum_n": n.sum(window = SlidingWindow(2, m > 10))
+        }
+    ).run_to_csv_string()
+    print(result)
+
+    assert result == "\n".join(
+        [
+            "_time,_subsort,_key_hash,_key,m,sum_m,n,sum_n",
+            "1996-12-20 00:39:57,0,12960666915911099378,A,5.0,5,10.0,10",
+            "1996-12-20 00:39:58,1,2867199309159137213,B,24.0,24,3.0,3",
+            "1996-12-20 00:39:59,2,12960666915911099378,A,17.0,22,6.0,16",
+            "1996-12-20 00:40:00,3,12960666915911099378,A,,22,9.0,25",
+            "1996-12-20 00:40:01,4,12960666915911099378,A,12.0,34,,25",
+            "1996-12-20 00:40:02,5,12960666915911099378,A,,34,,9",
+            "",
+        ]
+    )

--- a/sparrow-py/pytests/record_test.py
+++ b/sparrow-py/pytests/record_test.py
@@ -51,7 +51,6 @@ def test_extend_record(source) -> None:
     m = source["m"]
     n = source["n"]
     result = source.extend({"add": m + n}).run_to_csv_string()
-    print(result)
 
     assert result == "\n".join(
         [
@@ -70,7 +69,6 @@ def test_extend_record(source) -> None:
 def test_select_record(source) -> None:
     """Test we can select some fields from a record."""
     result = source.select("m", "n").run_to_csv_string()
-    print(result)
     assert result == "\n".join(
         [
             "_time,_subsort,_key_hash,_key,time,key,m",

--- a/sparrow-py/pytests/udf_test.py
+++ b/sparrow-py/pytests/udf_test.py
@@ -20,7 +20,6 @@ def test_numeric_udf_pure_python() -> None:
     x = pa.array([1, 12, 17, 23, 28], type=pa.int8())
     y = pa.array([1, 13, 18, 20, 4], type=pa.int8())
     result = add.run_pyarrow(pa.int8(), x, y)
-    print(result)
     assert result == pa.array([2, 25, 35, 43, 32], type=pa.int8())
 
 
@@ -29,5 +28,4 @@ def test_numeric_udf_rust() -> None:
     x = pa.array([1, 12, 17, 23, 28], type=pa.int8())
     y = pa.array([1, 13, 18, 20, 4], type=pa.int8())
     result = call_udf(add, pa.int8(), x, y)
-    print(result)
     assert result == pa.array([2, 25, 35, 43, 32], type=pa.int8())


### PR DESCRIPTION
Introduces Python classes for representing windows and flattens them into arguments for the corresponding aggregation functions.

This also changes the AST to DFG logic so that it only tries to flatten if the original AST is available. This does mean that ticks won't be recreated, meaning they won't have the proper domain.

Both of these likely need to be extended to cover other aggregations.