### PR TITLE
fix: Aggregations in sparrow-py

### DIFF
--- a/crates/sparrow-compiler/src/functions/function.rs
+++ b/crates/sparrow-compiler/src/functions/function.rs
@@ -123,6 +123,10 @@ impl Function {
         &self.signature
     }
 
+    pub fn internal_signature(&self) -> &Signature {
+        self.internal_signature.as_ref().unwrap_or(&self.signature)
+    }
+
     pub fn signature_str(&self) -> &'static str {
         self.signature_str
     }

--- a/crates/sparrow-session/src/session.rs
+++ b/crates/sparrow-session/src/session.rs
@@ -181,12 +181,13 @@ impl Session {
                 };
 
                 // TODO: Make this a proper error (not an assertion).
+                let signature = function.internal_signature();
+                signature.assert_valid_argument_count(args.len());
 
-                function.signature().assert_valid_argument_count(args.len());
-
-                let has_vararg = args.len() > function.signature().arg_names().len();
+                let has_vararg =
+                    signature.parameters().has_vararg && args.len() > signature.arg_names().len();
                 let args = Resolved::new(
-                    function.signature().arg_names().into(),
+                    signature.arg_names().into(),
                     args.into_iter()
                         .map(|arg| Located::builder(arg.0))
                         .collect(),

--- a/sparrow-py/Cargo.lock
+++ b/sparrow-py/Cargo.lock
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-api"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-arrow"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-compiler"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-instructions"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-kernels"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-plan"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-qfr"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "cpu-time",
  "derive_more",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-runtime"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-session"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "sparrow-syntax"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/sparrow-py/pytests/expr_test.py
+++ b/sparrow-py/pytests/expr_test.py
@@ -28,7 +28,7 @@ def test_field_ref(source1) -> None:
 
 def test_field_ref_no_such_field(source1) -> None:
     """Test error when there is no such field."""
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Illegal field reference"):
         # This raises a "NoSuchAttribute" error.
         # We currently catch this in Python and don't do anything to
         # suggest possible alternatives.
@@ -36,14 +36,12 @@ def test_field_ref_no_such_field(source1) -> None:
         # TODO: We should either surface the Sparrow error which suggests
         # possible field names, or improve the Python error.
         source1["foo"]
-    assert "Illegal field reference" == str(e.value)
 
 
 def test_field_ref_not_a_struct(source1) -> None:
     """Test error when there the base is not a struct."""
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError, match="Cannot index into double"):
         source1["x"]["x"]
-    assert "Cannot index into double" == str(e.value)
 
 
 def test_expr(source1) -> None:


### PR DESCRIPTION
Specifically, the previous fix straightened out some signatures, but didn't actually use the internal (DFG) signatures for the builder.