### PR TITLE
ref: Use a dataclass for execution options

### DIFF
--- a/sparrow-py/pysrc/sparrow_py/__init__.py
+++ b/sparrow-py/pysrc/sparrow_py/__init__.py
@@ -4,6 +4,7 @@ from typing import List
 from typing import Union
 
 from . import sources
+from ._execution import ExecutionOptions
 from ._expr import Expr
 from ._result import Result
 from ._session import init_session
@@ -21,12 +22,13 @@ def record(fields: Dict[str, Expr]) -> Expr:
 
 
 __all__ = [
+    "ExecutionOptions",
     "Expr",
     "init_session",
     "record",
-    "Window",
+    "Result",
     "SinceWindow",
     "SlidingWindow",
     "sources",
-    "Result",
+    "Window",
 ]

--- a/sparrow-py/pysrc/sparrow_py/_execution.py
+++ b/sparrow-py/pysrc/sparrow_py/_execution.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class ExecutionOptions:
+    """Execution options for a query.
+
+    Attributes
+    ----------
+    row_limit : Optional[int]
+        The maximum number of rows to return.
+        If not specified (the default), all rows are returned.
+    """
+
+    row_limit: Optional[int] = None

--- a/sparrow-py/pysrc/sparrow_py/_execution.py
+++ b/sparrow-py/pysrc/sparrow_py/_execution.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+
 @dataclass
 class ExecutionOptions:
     """Execution options for a query.

--- a/sparrow-py/pysrc/sparrow_py/_expr.py
+++ b/sparrow-py/pysrc/sparrow_py/_expr.py
@@ -369,8 +369,8 @@ def _aggregation(
     if window is None:
         return Expr.call(op, *args, input, None, None)
     elif isinstance(window, kt.SinceWindow):
-        return Expr.call(op, *args, input, window._predicate, None)
+        return Expr.call(op, *args, input, window.predicate, None)
     elif isinstance(window, kt.SlidingWindow):
-        return Expr.call(op, *args, input, window._predicate, window._duration)
+        return Expr.call(op, *args, input, window.predicate, window.duration)
     else:
         raise NotImplementedError(f"Unknown window type {window!r}")

--- a/sparrow-py/pysrc/sparrow_py/_expr.py
+++ b/sparrow-py/pysrc/sparrow_py/_expr.py
@@ -11,9 +11,10 @@ from typing import final
 
 import pandas as pd
 import pyarrow as pa
-from ._execution import ExecutionOptions
 import sparrow_py as kt
 import sparrow_py._ffi as _ffi
+
+from ._execution import ExecutionOptions
 
 
 #: The type of arguments to expressions.

--- a/sparrow-py/pysrc/sparrow_py/_expr.py
+++ b/sparrow-py/pysrc/sparrow_py/_expr.py
@@ -11,6 +11,7 @@ from typing import final
 
 import pandas as pd
 import pyarrow as pa
+from ._execution import ExecutionOptions
 import sparrow_py as kt
 import sparrow_py._ffi as _ffi
 
@@ -323,7 +324,7 @@ class Expr(object):
 
     def run(self, row_limit: Optional[int] = None) -> pd.DataFrame:
         """Run the expression."""
-        options = _ffi.ExecutionOptions(row_limit=row_limit)
+        options = ExecutionOptions(row_limit=row_limit)
         batches = self._ffi_expr.execute(options).collect_pyarrow()
         schema = batches[0].schema
         table = pa.Table.from_batches(batches, schema=schema)

--- a/sparrow-py/pysrc/sparrow_py/_ffi.pyi
+++ b/sparrow-py/pysrc/sparrow_py/_ffi.pyi
@@ -3,8 +3,9 @@ from typing import Optional
 from typing import Sequence
 
 import pyarrow as pa
-from .udf import Udf
+
 from ._execution import ExecutionOptions
+from .udf import Udf
 
 class Session:
     def __init__(self) -> None: ...

--- a/sparrow-py/pysrc/sparrow_py/_ffi.pyi
+++ b/sparrow-py/pysrc/sparrow_py/_ffi.pyi
@@ -3,14 +3,11 @@ from typing import Optional
 from typing import Sequence
 
 import pyarrow as pa
-from sparrow_py.udf import Udf
+from .udf import Udf
+from ._execution import ExecutionOptions
 
 class Session:
     def __init__(self) -> None: ...
-
-class ExecutionOptions(object):
-    def __init__(self, row_limit: Optional[int] = None) -> None: ...
-    row_limit: Optional[int]
 
 class Execution(object):
     def collect_pyarrow(self) -> List[pa.RecordBatch]: ...

--- a/sparrow-py/pysrc/sparrow_py/_windows.py
+++ b/sparrow-py/pysrc/sparrow_py/_windows.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
+
 from ._expr import Expr
 
-@dataclass(frozen = True)
+
+@dataclass(frozen=True)
 class Window(object):
     """Base class for window functions."""
 
-@dataclass(frozen = True)
+
+@dataclass(frozen=True)
 class SinceWindow(Window):
     """
     Window since the last time a predicate was true.
@@ -19,13 +22,14 @@ class SinceWindow(Window):
         The predicate to use for the window.
         Each time the predicate evaluates to true the window will be cleared.
     """
+
     predicate: Expr
 
-@dataclass(frozen = True)
+
+@dataclass(frozen=True)
 class SlidingWindow(Window):
     """
-    Sliding windows where the width of the window is determined by the
-    number of times (`duration`) the `predicate` is `true`.
+    Window for the last `duration` intervals of some `predicate`.
 
     Parameters
     ----------

--- a/sparrow-py/pysrc/sparrow_py/_windows.py
+++ b/sparrow-py/pysrc/sparrow_py/_windows.py
@@ -1,25 +1,41 @@
-import sparrow_py
+from dataclasses import dataclass
+from ._expr import Expr
 
-
+@dataclass(frozen = True)
 class Window(object):
     """Base class for window functions."""
 
-    def __init__(self) -> None:
-        pass
-
-
+@dataclass(frozen = True)
 class SinceWindow(Window):
-    """Window since the last time a predicate was true."""
+    """
+    Window since the last time a predicate was true.
 
-    def __init__(self, predicate: "sparrow_py.Expr") -> None:
-        super().__init__()
-        self._predicate = predicate
+    Aggregations will contain all values starting from the last time the predicate
+    evaluated to true (inclusive).
 
+    Parameters
+    ----------
+    predicate : Expr
+        The predicate to use for the window.
+        Each time the predicate evaluates to true the window will be cleared.
+    """
+    predicate: Expr
 
+@dataclass(frozen = True)
 class SlidingWindow(Window):
-    """Sliding windows where the width is a multiple of some condition."""
+    """
+    Sliding windows where the width of the window is determined by the
+    number of times (`duration`) the `predicate` is `true`.
 
-    def __init__(self, duration: int, predicate: "sparrow_py.Expr") -> None:
-        super().__init__()
-        self._duration = duration
-        self._predicate = predicate
+    Parameters
+    ----------
+    duration : int
+        The number of sliding intervals to use in the window.
+
+    predicate : Expr
+        The predicate to use for the window.
+        Each time the predicate evaluates to true the window starts a new interval.
+    """
+
+    duration: int
+    predicate: Expr

--- a/sparrow-py/src/execution.rs
+++ b/sparrow-py/src/execution.rs
@@ -4,13 +4,6 @@ use sparrow_session::Execution as RustExecution;
 
 use crate::error::{Error, ErrorContext};
 
-#[pyclass]
-#[derive(Default)]
-pub(crate) struct ExecutionOptions {
-    #[pyo3(get, set)]
-    pub(crate) row_limit: Option<usize>,
-}
-
 /// Kaskada execution object.
 #[pyclass]
 pub(crate) struct Execution(Option<RustExecution>);
@@ -34,21 +27,5 @@ impl Execution {
             .map(|batch| batch.to_pyarrow(py))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(results)
-    }
-}
-
-#[pymethods]
-impl ExecutionOptions {
-    #[new]
-    fn new(row_limit: Option<usize>) -> Self {
-        Self { row_limit }
-    }
-}
-
-impl ExecutionOptions {
-    pub(crate) fn to_rust_options(&self) -> sparrow_session::ExecutionOptions {
-        sparrow_session::ExecutionOptions {
-            row_limit: self.row_limit,
-        }
     }
 }

--- a/sparrow-py/src/lib.rs
+++ b/sparrow-py/src/lib.rs
@@ -18,7 +18,6 @@ fn ffi(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<expr::Expr>()?;
     m.add_class::<table::Table>()?;
     m.add_class::<execution::Execution>()?;
-    m.add_class::<execution::ExecutionOptions>()?;
 
     Ok(())
 }


### PR DESCRIPTION
This reduces some duplication, in that we don't need to have the FFI define a Python-compatible copy of the Rust execution options. Instead we have it read straight from the documented dataclass.