### PR TITLE
docs: Some doc tweaks

### DIFF
--- a/sparrow-py/README.md
+++ b/sparrow-py/README.md
@@ -14,7 +14,7 @@ It is built on Apache Arrow, using the same columnar execution strategy that mak
 
 ## Install Python
 
-Use `pyenv` and install at least `3.7` or `3.8`.
+Use `pyenv` and install at least `3.8` (most development occurs under `3.11`).
 If multiple versions are installed, `nox` will test against each of them.
 
 ## Building and Testing

--- a/sparrow-py/docs/source/conf.py
+++ b/sparrow-py/docs/source/conf.py
@@ -2,6 +2,13 @@
 from typing import Any
 from typing import Dict
 
+import os
+import sys
+sys.path[0] = os.path.abspath(os.path.join("..", "..", "pysrc", "sparrow_py"))
+print(sys.path)
+
+import sparrow_py
+
 project = "sparrow-py"
 author = "Kaskada Contributors"
 copyright = "2023, Kaskada Contributors"
@@ -30,7 +37,7 @@ html_theme_options: Dict[str, Any] = {
     "use_edit_page_button": True,
     "use_issues_button": True,
     "repository_branch": "main",
-    "path_to_docs": "sparrow-py/docs/",
+    "path_to_docs": "sparrow-py/docs/source",
     "icon_links": [
         {
             "name": "GitHub",
@@ -55,7 +62,7 @@ html_context = {
     "github_user": "kaskada-ai",
     "github_repo": "kaskada",
     "github_version": "main",
-    "doc_path": "sparrow-py/docs/",
+    "doc_path": "sparrow-py/docs/source",
 }
 
 intersphinx_mapping: Dict[str, Any] = {
@@ -92,6 +99,6 @@ autodoc_typehints = "description"
 # Don't show class signature with the class' name.
 autodoc_class_signature = "separated"
 
-autodoc_type_aliases = { 'Arg': 'sparrow_py.Arg' }
-
 autosummary_generate = True
+
+napoleon_preprocess_types = True

--- a/sparrow-py/docs/source/index.md
+++ b/sparrow-py/docs/source/index.md
@@ -4,10 +4,20 @@ hide-toc: true
 
 # Kaskada Timestreams
 
-```{include} ../README.md
+```{include} ../../README.md
 :start-after: <!-- start elevator-pitch -->
 :end-before: <!-- end elevator-pitch -->
 ```
+
+## What are "Timestreams"?
+A [Timestream](reference/timestream/index) describes how a value changes over time. In the same way that SQL
+queries transform tables and graph queries transform nodes and edges,
+Kaskada queries transform Timestreams.
+
+In comparison to a timeseries which often contains simple values (e.g., numeric
+observations) defined at fixed, periodic times (i.e., every minute), a Timestream
+contains any kind of data (records or collections as well as primitives) and may
+be defined at arbitrary times corresponding to when the events occur.
 
 ## Getting Started with Timestreams
 
@@ -24,16 +34,6 @@ data = t.sources.Parquet.from_file(
 # Get the count of events associated with each user over time, as a dataframe.
 data.count().run().to_pandas()
 ```
-
-## What are "Timestreams"?
-A [Timestream](reference/timestream/index) describes how a value changes over time. In the same way that SQL
-queries transform tables and graph queries transform nodes and edges,
-Kaskada queries transform Timestreams.
-
-In comparison to a timeseries which often contains simple values (e.g., numeric
-observations) defined at fixed, periodic times (i.e., every minute), a Timestream
-contains any kind of data (records or collections as well as primitives) and may
-be defined at arbitrary times corresponding to when the events occur.
 
 ```{toctree}
 :hidden:

--- a/sparrow-py/docs/source/reference/timestream/index.md
+++ b/sparrow-py/docs/source/reference/timestream/index.md
@@ -1,17 +1,11 @@
 # Timestream
 
-```{todo}
-- [ ] Expand the `Arg` type alias in timestreams accordingly.
-```
-
 ```{eval-rst}
 .. currentmodule:: sparrow_py
 
-.. autoclass:: Timestream
-    :members:
-    :noindex:
-    :autosummary:
-    :autosummary-nosignatures:
+.. autoclass:: sparrow_py.Literal
+.. autoclass:: sparrow_py.Timestream
+    :exclude-members: __init__
 ```
 
 ```{toctree}

--- a/sparrow-py/poetry.lock
+++ b/sparrow-py/poetry.lock
@@ -740,13 +740,13 @@ testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs
 
 [[package]]
 name = "importlib-resources"
-version = "6.0.0"
+version = "6.0.1"
 description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.0.0-py3-none-any.whl", hash = "sha256:d952faee11004c045f785bb5636e8f885bed30dc3c940d5d42798a2a4541c185"},
-    {file = "importlib_resources-6.0.0.tar.gz", hash = "sha256:4cf94875a8368bd89531a756df9a9ebe1f150e0f885030b461237bc7f2d905f2"},
+    {file = "importlib_resources-6.0.1-py3-none-any.whl", hash = "sha256:134832a506243891221b88b4ae1213327eea96ceb4e407a00d790bb0626f45cf"},
+    {file = "importlib_resources-6.0.1.tar.gz", hash = "sha256:4359457e42708462b9626a04657c6208ad799ceb41e5c58c57ffa0e6a098a5d4"},
 ]
 
 [package.dependencies]
@@ -769,13 +769,13 @@ files = [
 
 [[package]]
 name = "ipykernel"
-version = "6.25.0"
+version = "6.25.1"
 description = "IPython Kernel for Jupyter"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ipykernel-6.25.0-py3-none-any.whl", hash = "sha256:f0042e867ac3f6bca1679e6a88cbd6a58ed93a44f9d0866aecde6efe8de76659"},
-    {file = "ipykernel-6.25.0.tar.gz", hash = "sha256:e342ce84712861be4b248c4a73472be4702c1b0dd77448bfd6bcfb3af9d5ddf9"},
+    {file = "ipykernel-6.25.1-py3-none-any.whl", hash = "sha256:c8a2430b357073b37c76c21c52184db42f6b4b0e438e1eb7df3c4440d120497c"},
+    {file = "ipykernel-6.25.1.tar.gz", hash = "sha256:050391364c0977e768e354bdb60cbbfbee7cbb943b1af1618382021136ffd42f"},
 ]
 
 [package.dependencies]
@@ -894,13 +894,13 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.18.6"
+version = "4.19.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jsonschema-4.18.6-py3-none-any.whl", hash = "sha256:dc274409c36175aad949c68e5ead0853aaffbe8e88c830ae66bb3c7a1728ad2d"},
-    {file = "jsonschema-4.18.6.tar.gz", hash = "sha256:ce71d2f8c7983ef75a756e568317bf54bc531dc3ad7e66a128eae0d51623d8a3"},
+    {file = "jsonschema-4.19.0-py3-none-any.whl", hash = "sha256:043dc26a3845ff09d20e4420d6012a9c91c9aa8999fa184e7efcfeccb41e32cb"},
+    {file = "jsonschema-4.19.0.tar.gz", hash = "sha256:6e1e7569ac13be8139b2dd2c21a55d350066ee3f80df06c608b398cdc6f30e8f"},
 ]
 
 [package.dependencies]
@@ -1017,13 +1017,13 @@ tornado = {version = "*", markers = "python_version > \"2.7\""}
 
 [[package]]
 name = "markdown-it-py"
-version = "2.2.0"
+version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "markdown-it-py-2.2.0.tar.gz", hash = "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"},
-    {file = "markdown_it_py-2.2.0-py3-none-any.whl", hash = "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30"},
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
 ]
 
 [package.dependencies]
@@ -1036,7 +1036,7 @@ compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0
 linkify = ["linkify-it-py (>=1,<3)"]
 plugins = ["mdit-py-plugins"]
 profiling = ["gprof2dot"]
-rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
@@ -1114,24 +1114,24 @@ traitlets = "*"
 
 [[package]]
 name = "maturin"
-version = "1.1.0"
+version = "1.2.0"
 description = "Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "maturin-1.1.0-py3-none-linux_armv6l.whl", hash = "sha256:eb04f3473b9f283eba51a5dc20dc0bab6f8741048c1bbc5e45f39cc29ad69aa6"},
-    {file = "maturin-1.1.0-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:eee3c9b2cd80adee6938ea1828882795e261a7fc6b5ebaed15003ed4d713adaa"},
-    {file = "maturin-1.1.0-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:9042ea6538529e22954c0a4eefbe55026a9eba45484423882dd8eb97854b29dd"},
-    {file = "maturin-1.1.0-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:4252241c196abf0ede0088e38bc3c181fe0bf073a974d6594493f3ae7232545c"},
-    {file = "maturin-1.1.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:6f63dc6f9dba2081346f0ff40019e67a72eb20af7ee4847dc21174dd3636a981"},
-    {file = "maturin-1.1.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:c0fecd5ae4f8bad703ee648873d837e3bd6eb846f48ff8607bfb0556a2010adc"},
-    {file = "maturin-1.1.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:19332aa0830f23813e461f61e4d2b7d0c6f8ec84c335040232aafea3f068ac31"},
-    {file = "maturin-1.1.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:3f6f1e8e970f7728c26eeb55b4c38103f2c5d830b9df4c12fd00903eef7a4114"},
-    {file = "maturin-1.1.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a2398df2d2f5ba4970ac7f670108e7c7e2da39185caf9b9f9e67d14ae4315e2"},
-    {file = "maturin-1.1.0-py3-none-win32.whl", hash = "sha256:32e95212e6b334caf68d278bcc5137dde020a8e84095c2728d9b08d2311e5d64"},
-    {file = "maturin-1.1.0-py3-none-win_amd64.whl", hash = "sha256:47705b6c5b5ec9d883f6b4fb6ae2480a07a77aabbfbc658d6327c9d6cd74c7cf"},
-    {file = "maturin-1.1.0-py3-none-win_arm64.whl", hash = "sha256:a36efcca897b356deee56c7a3c399c595201518a892ec0f20f0f20abb3064ccb"},
-    {file = "maturin-1.1.0.tar.gz", hash = "sha256:4650aeaa8debd004b55aae7afb75248cbd4d61cd7da2dcf4ead8b22b58cecae0"},
+    {file = "maturin-1.2.0-py3-none-linux_armv6l.whl", hash = "sha256:cc60957012cfd3f662cd313ca0cdaac64f5f5cd6ddbbbc2a1ddab341ccc28e4d"},
+    {file = "maturin-1.2.0-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:02a3ec65872b294d012824d9af5a445ea614140f6fc55c16f07af04622450de3"},
+    {file = "maturin-1.2.0-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:2fb701d44c68849e4cf41d92f6aeefcc166edecccc3b0c0a430a003190dc5b2e"},
+    {file = "maturin-1.2.0-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:adbf64b6ec763fc9ece32bfa0979335f79333106aabf34415ae7c72ed8b432af"},
+    {file = "maturin-1.2.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:03207fcb64d3a340f353de57186e3614478430ad09887e68438739b724096782"},
+    {file = "maturin-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:0d8bfa63522a454ff862c6680575255e28fa0f634d206fb5af84c73f5f5fabf0"},
+    {file = "maturin-1.2.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:c013cf9aa0156ac25df06fa7c06edd1d115723c8c270cb25e0060bc0d25c72d5"},
+    {file = "maturin-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:840803f176c12a56bd023a13dc0e6fef63bc0480665ee9eeda9ed527a6ccb8dc"},
+    {file = "maturin-1.2.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0946b9badd053c92962770aad9133d6fc9cdbc98eb8c707e808f0c5c9005651"},
+    {file = "maturin-1.2.0-py3-none-win32.whl", hash = "sha256:955d9d46cf00a8887954d5e37ab3f28dc75d46caeddb4e8e43366e39c803a3b9"},
+    {file = "maturin-1.2.0-py3-none-win_amd64.whl", hash = "sha256:138526c3275eeebb1bd566c20aae6a76f39cf55991f127c81dd79da725f45d59"},
+    {file = "maturin-1.2.0-py3-none-win_arm64.whl", hash = "sha256:45f90cac503bacfa6c20e112836b2f53a3355b7b913471f5a104f2c4b09c5b9c"},
+    {file = "maturin-1.2.0.tar.gz", hash = "sha256:bf5986127e7dd3f6e5403dc737f260e1c425c5b7b017a492abe85f38955c6beb"},
 ]
 
 [package.dependencies]
@@ -1154,21 +1154,21 @@ files = [
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.3.5"
+version = "0.4.0"
 description = "Collection of plugins for markdown-it-py"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "mdit-py-plugins-0.3.5.tar.gz", hash = "sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a"},
-    {file = "mdit_py_plugins-0.3.5-py3-none-any.whl", hash = "sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e"},
+    {file = "mdit_py_plugins-0.4.0-py3-none-any.whl", hash = "sha256:b51b3bb70691f57f974e257e367107857a93b36f322a9e6d44ca5bf28ec2def9"},
+    {file = "mdit_py_plugins-0.4.0.tar.gz", hash = "sha256:d8ab27e9aed6c38aa716819fedfde15ca275715955f8a185a8e1cf90fb1d2c1b"},
 ]
 
 [package.dependencies]
-markdown-it-py = ">=1.0.0,<3.0.0"
+markdown-it-py = ">=1.0.0,<4.0.0"
 
 [package.extras]
 code-style = ["pre-commit"]
-rtd = ["attrs", "myst-parser (>=0.16.1,<0.17.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
+rtd = ["myst-parser", "sphinx-book-theme"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
@@ -1241,57 +1241,61 @@ files = [
 
 [[package]]
 name = "myst-nb"
-version = "0.17.2"
+version = "0.18.0"
 description = "A Jupyter Notebook Sphinx reader built on top of the MyST markdown parser."
 optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "myst-nb-0.17.2.tar.gz", hash = "sha256:0f61386515fab07c73646adca97fff2f69f41e90d313a260217c5bbe419d858b"},
-    {file = "myst_nb-0.17.2-py3-none-any.whl", hash = "sha256:132ca4d0f5c308fdd4b6fdaba077712e28e119ccdafd04d6e41b51aac5483494"},
-]
+python-versions = ">=3.8"
+files = []
+develop = false
 
 [package.dependencies]
 importlib_metadata = "*"
 ipykernel = "*"
 ipython = "*"
 jupyter-cache = ">=0.5,<0.7"
-myst-parser = ">=0.18.0,<0.19.0"
+myst-parser = ">=0.18.0"
 nbclient = "*"
 nbformat = ">=5.0,<6.0"
 pyyaml = "*"
-sphinx = ">=4,<6"
+sphinx = ">=4"
 typing-extensions = "*"
 
 [package.extras]
 code-style = ["pre-commit"]
-rtd = ["alabaster", "altair", "bokeh", "coconut (>=1.4.3,<2.3.0)", "ipykernel (>=5.5,<6.0)", "ipywidgets", "jupytext (>=1.11.2,<1.12.0)", "matplotlib", "numpy", "pandas", "plotly", "sphinx-book-theme (>=0.3.0,<0.4.0)", "sphinx-copybutton", "sphinx-design (>=0.4.0,<0.5.0)", "sphinxcontrib-bibtex", "sympy"]
-testing = ["beautifulsoup4", "coverage (>=6.4,<8.0)", "ipykernel (>=5.5,<6.0)", "ipython (!=8.1.0,<8.5)", "ipywidgets (>=8)", "jupytext (>=1.11.2,<1.12.0)", "matplotlib (>=3.5.3,<3.6)", "nbdime", "numpy", "pandas", "pytest (>=7.1,<8.0)", "pytest-cov (>=3,<5)", "pytest-param-files (>=0.3.3,<0.4.0)", "pytest-regressions", "sympy (>=1.10.1)"]
+rtd = ["alabaster", "altair", "bokeh", "coconut (>=1.4.3,<3.1.0)", "ipykernel (>=5.5,<7.0)", "ipywidgets", "jupytext (>=1.11.2,<1.15.0)", "matplotlib", "numpy", "pandas", "plotly", "sphinx-book-theme (>=0.3)", "sphinx-copybutton", "sphinx-design (>=0.4.0,<0.5.0)", "sphinxcontrib-bibtex", "sympy"]
+testing = ["beautifulsoup4", "coverage (>=6.4,<8.0)", "ipykernel (>=5.5,<7.0)", "ipython (!=8.1.0,<8.15)", "ipywidgets (>=8)", "jupytext (>=1.11.2,<1.15.0)", "matplotlib (>=3.5.3,<3.6)", "nbdime", "numpy", "pandas", "pytest (>=7.1,<8.0)", "pytest-cov (>=3,<5)", "pytest-param-files (>=0.3.3,<0.4.0)", "pytest-regressions", "sympy (>=1.10.1)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/executablebooks/MyST-NB.git"
+reference = "3d6a5d1"
+resolved_reference = "3d6a5d16d808dd9dfe95f71e5c0b6f08c7c3cc00"
 
 [[package]]
 name = "myst-parser"
-version = "0.18.1"
-description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
+version = "2.0.0"
+description = "An extended [CommonMark](https://spec.commonmark.org/) compliant parser,"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "myst-parser-0.18.1.tar.gz", hash = "sha256:79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d"},
-    {file = "myst_parser-0.18.1-py3-none-any.whl", hash = "sha256:61b275b85d9f58aa327f370913ae1bec26ebad372cc99f3ab85c8ec3ee8d9fb8"},
+    {file = "myst_parser-2.0.0-py3-none-any.whl", hash = "sha256:7c36344ae39c8e740dad7fdabf5aa6fc4897a813083c6cc9990044eb93656b14"},
+    {file = "myst_parser-2.0.0.tar.gz", hash = "sha256:ea929a67a6a0b1683cdbe19b8d2e724cd7643f8aa3e7bb18dd65beac3483bead"},
 ]
 
 [package.dependencies]
-docutils = ">=0.15,<0.20"
+docutils = ">=0.16,<0.21"
 jinja2 = "*"
-markdown-it-py = ">=1.0.0,<3.0.0"
-mdit-py-plugins = ">=0.3.1,<0.4.0"
+markdown-it-py = ">=3.0,<4.0"
+mdit-py-plugins = ">=0.4,<1.0"
 pyyaml = "*"
-sphinx = ">=4,<6"
-typing-extensions = "*"
+sphinx = ">=6,<8"
 
 [package.extras]
-code-style = ["pre-commit (>=2.12,<3.0)"]
-linkify = ["linkify-it-py (>=1.0,<2.0)"]
-rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
-testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx (<5.2)", "sphinx-pytest"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+linkify = ["linkify-it-py (>=2.0,<3.0)"]
+rtd = ["ipython", "pydata-sphinx-theme (==v0.13.0rc4)", "sphinx-autodoc2 (>=0.4.2,<0.5.0)", "sphinx-book-theme (==1.0.0rc2)", "sphinx-copybutton", "sphinx-design2", "sphinx-pyscript", "sphinx-tippy (>=0.3.1)", "sphinx-togglebutton", "sphinxext-opengraph (>=0.8.2,<0.9.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
+testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=7,<8)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx-pytest"]
+testing-docutils = ["pygments", "pytest (>=7,<8)", "pytest-param-files (>=0.3.4,<0.4.0)"]
 
 [[package]]
 name = "nbclient"
@@ -1763,13 +1767,13 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.15.1"
+version = "2.16.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
-    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
+    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
+    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
 ]
 
 [package.extras]
@@ -1999,13 +2003,13 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "referencing"
-version = "0.30.1"
+version = "0.30.2"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "referencing-0.30.1-py3-none-any.whl", hash = "sha256:185d4a29f001c6e8ae4dad3861e61282a81cb01b9f0ef70a15450c45c6513a0d"},
-    {file = "referencing-0.30.1.tar.gz", hash = "sha256:9370c77ceefd39510d70948bbe7375ce2d0125b9c11fd380671d4de959a8e3ce"},
+    {file = "referencing-0.30.2-py3-none-any.whl", hash = "sha256:449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf"},
+    {file = "referencing-0.30.2.tar.gz", hash = "sha256:794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"},
 ]
 
 [package.dependencies]
@@ -2290,26 +2294,26 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "5.3.0"
+version = "6.2.1"
 description = "Python documentation generator"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "Sphinx-5.3.0.tar.gz", hash = "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"},
-    {file = "sphinx-5.3.0-py3-none-any.whl", hash = "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d"},
+    {file = "Sphinx-6.2.1.tar.gz", hash = "sha256:6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b"},
+    {file = "sphinx-6.2.1-py3-none-any.whl", hash = "sha256:97787ff1fa3256a3eef9eda523a63dbf299f7b47e053cfcf684a1c2a8380c912"},
 ]
 
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
 babel = ">=2.9"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.14,<0.20"
+docutils = ">=0.18.1,<0.20"
 imagesize = ">=1.3"
 importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.0"
 packaging = ">=21.0"
-Pygments = ">=2.12"
-requests = ">=2.5.0"
+Pygments = ">=2.13"
+requests = ">=2.25.0"
 snowballstemmer = ">=2.0"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -2320,8 +2324,8 @@ sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-bugbear", "flake8-comprehensions", "flake8-simplify", "isort", "mypy (>=0.981)", "sphinx-lint", "types-requests", "types-typed-ast"]
-test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast"]
+lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-simplify", "isort", "mypy (>=0.990)", "ruff", "sphinx-lint", "types-requests"]
+test = ["cython", "filelock", "html5lib", "pytest (>=4.6)"]
 
 [[package]]
 name = "sphinx-autobuild"
@@ -2764,4 +2768,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "a5ad96e8e5eb7b138b856c383a45f84736ec2937a70b39957382efb5eab23334"
+content-hash = "f44a8796c5d29531f51da0509aab1e9f92b23d8b9aac63f0ab60e3b9d8589f91"

--- a/sparrow-py/pyproject.toml
+++ b/sparrow-py/pyproject.toml
@@ -7,6 +7,8 @@ authors = []
 [tool.poetry.dependencies]
 pandas = "^2.0.3"
 python = ">=3.8,<4.0"
+pyarrow = "^12.0.1"
+typing-extensions = "^4.7.1"
 
 [tool.poetry.dev-dependencies]
 maturin = "^1.1.0"
@@ -20,19 +22,21 @@ isort = ">=5.10.1"
 mypy = ">=0.930"
 pandas-stubs = "^2.0.2"
 pep8-naming = ">=0.12.1"
-pyarrow = "^12.0.1"
 pydocstyle = "^6.3.0"
 pytest = ">=6.2.5"
 pyupgrade = ">=2.29.1"
 safety = ">=1.10.3"
-sphinx = ">=4.3.2"
+sphinx = ">=6.0.0"
 sphinx-autobuild = ">=2021.3.14"
 sphinx-book-theme = "^1.0.1"
 sphinx-copybutton = "^0.5.2"
 typeguard = ">=2.13.3"
 xdoctest = {extras = ["colors"], version = ">=0.15.10"}
 myst-parser = {version = ">=0.16.1"}
-myst-nb = "^0.17.2"
+# Use myst-nb from git since the currently released version (0.17.2) pins
+# Sphinx to < 6. Once a new release occurs we can upgrade to `0.18.0` or newer.
+# https://github.com/executablebooks/MyST-NB/issues/530
+myst-nb = { git = "https://github.com/executablebooks/MyST-NB.git", rev = "3d6a5d1"}
 
 [tool.poetry.group.constraints]
 optional = true

--- a/sparrow-py/pysrc/sparrow_py/__init__.py
+++ b/sparrow-py/pysrc/sparrow_py/__init__.py
@@ -1,9 +1,11 @@
 """Kaskada query builder and local executon engine."""
+from __future__ import annotations
+
 from . import sources
 from ._execution import ExecutionOptions
 from ._result import Result
 from ._session import init_session
-from ._timestream import Arg
+from ._timestream import Literal
 from ._timestream import Timestream
 from ._timestream import record
 from ._windows import SinceWindow
@@ -12,14 +14,14 @@ from ._windows import Window
 
 
 __all__ = [
-    "Arg",
     "ExecutionOptions",
-    "Timestream",
     "init_session",
+    "Literal",
     "record",
     "Result",
     "SinceWindow",
     "SlidingWindow",
     "sources",
+    "Timestream",
     "Window",
 ]

--- a/sparrow-py/pysrc/sparrow_py/_timestream.py
+++ b/sparrow-py/pysrc/sparrow_py/_timestream.py
@@ -11,6 +11,7 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 from typing import final
+from typing_extensions import TypeAlias
 
 import pandas as pd
 import pyarrow as pa
@@ -21,13 +22,9 @@ from ._execution import ExecutionOptions
 from ._result import Result
 
 
-Arg = Union["Timestream", int, str, float, bool, None]
-"""
-The type of arguments to most Timestream functions.
-May be a Timestream, a literal (int, str, float, bool), or null (`None`).
-"""
+Literal = Union[int, str, float, bool, None]
 
-def _augment_error(args: Sequence[Arg], e: Exception) -> Exception:
+def _augment_error(args: Sequence[Union[Timestream, Literal]], e: Exception) -> Exception:
     """Augment an error with information about the arguments."""
     if sys.version_info >= (3, 11):
         # If we can add notes to the exception, indicate the types.
@@ -52,7 +49,7 @@ class Timestream(object):
         self._ffi_expr = ffi
 
     @staticmethod
-    def _call(func: str, *args: Arg) -> Timestream:
+    def _call(func: str, *args: Union[Timestream, Literal]) -> Timestream:
         """
         Construct a new Timestream by calling the given function.
 
@@ -101,8 +98,8 @@ class Timestream(object):
         func: Union[
             Callable[..., Timestream], Tuple[Callable[..., Timestream], str]
         ],
-        *args: Arg,
-        **kwargs: Arg,
+        *args: Union[Timestream, Literal],
+        **kwargs: Union[Timestream, Literal],
     ) -> Timestream:
         """
         Apply chainable functions that produce Timestreams.
@@ -165,13 +162,13 @@ class Timestream(object):
         else:
             return func(self, *args, **kwargs)
 
-    def __add__(self, rhs: Arg) -> Timestream:
+    def __add__(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream adding this and `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to add to this.
 
         Returns
@@ -181,13 +178,13 @@ class Timestream(object):
         """
         return Timestream._call("add", self, rhs)
 
-    def __radd__(self, lhs: Arg) -> Timestream:
+    def __radd__(self, lhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream adding `lhs` and this.
 
         Parameters
         ----------
-        lhs : Arg
+        lhs : Union[Timestream, Literal]
             The Timestream or literal value to add to this.
 
         Returns
@@ -197,13 +194,13 @@ class Timestream(object):
         """
         return Timestream._call("add", lhs, self)
 
-    def __sub__(self, rhs: Arg) -> Timestream:
+    def __sub__(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream substracting `rhs` from this.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to subtract from this.
 
         Returns
@@ -213,13 +210,13 @@ class Timestream(object):
         """
         return Timestream._call("sub", self, rhs)
 
-    def __rsub__(self, lhs: Arg) -> Timestream:
+    def __rsub__(self, lhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream substracting this from the `lhs`.
 
         Parameters
         ----------
-        lhs : Arg
+        lhs : Union[Timestream, Literal]
             The Timestream or literal value to subtract this from.
 
         Returns
@@ -229,13 +226,13 @@ class Timestream(object):
         """
         return Timestream._call("sub", lhs, self)
 
-    def __mul__(self, rhs: Arg) -> Timestream:
+    def __mul__(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream multiplying this and `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to multiply with this.
 
         Returns
@@ -245,13 +242,13 @@ class Timestream(object):
         """
         return Timestream._call("mul", self, rhs)
 
-    def __rmul__(self, lhs: Arg) -> Timestream:
+    def __rmul__(self, lhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream multiplying `lhs` and this.
 
         Parameters
         ----------
-        lhs : Arg
+        lhs : Union[Timestream, Literal]
             The Timestream or literal value to multiply with this.
 
         Returns
@@ -261,13 +258,13 @@ class Timestream(object):
         """
         return Timestream._call("mul", lhs, self)
 
-    def __truediv__(self, divisor: Arg) -> Timestream:
+    def __truediv__(self, divisor: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream by dividing this and `divisor`.
 
         Parameters
         ----------
-        divisor : Arg
+        divisor : Union[Timestream, Literal]
             The Timestream or literal value to divide this by.
 
         Returns
@@ -277,13 +274,13 @@ class Timestream(object):
         """
         return Timestream._call("div", self, divisor)
 
-    def __rtruediv__(self, dividend: Arg) -> Timestream:
+    def __rtruediv__(self, dividend: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream by dividing this and `dividend`.
 
         Parameters
         ----------
-        dividend : Arg
+        dividend : Union[Timestream, Literal]
             The Timestream or literal value to divide by this.
 
         Returns
@@ -293,13 +290,13 @@ class Timestream(object):
         """
         return Timestream._call("div", dividend, self)
 
-    def __lt__(self, rhs: Arg) -> Timestream:
+    def __lt__(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream that is true if this is less than `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to compare to.
 
         Returns
@@ -309,13 +306,13 @@ class Timestream(object):
         """
         return Timestream._call("lt", self, rhs)
 
-    def __le__(self, rhs: Arg) -> Timestream:
+    def __le__(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream that is true if this is less than or equal to `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to compare to.
 
         Returns
@@ -325,13 +322,13 @@ class Timestream(object):
         """
         return Timestream._call("lte", self, rhs)
 
-    def __gt__(self, rhs: Arg) -> Timestream:
+    def __gt__(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream that is true if this is greater than `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to compare to.
 
         Returns
@@ -341,13 +338,13 @@ class Timestream(object):
         """
         return Timestream._call("gt", self, rhs)
 
-    def __ge__(self, rhs: Arg) -> Timestream:
+    def __ge__(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream that is true if this is greater than or equal to `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to compare to.
 
         Returns
@@ -357,13 +354,13 @@ class Timestream(object):
         """
         return Timestream._call("gte", self, rhs)
 
-    def and_(self, rhs: Arg) -> Timestream:
+    def and_(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create the logical conjunction of this Timestream and `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to conjoin with.
 
         Returns
@@ -373,13 +370,13 @@ class Timestream(object):
         """
         return Timestream._call("logical_and", self, rhs)
 
-    def or_(self, rhs: Arg) -> Timestream:
+    def or_(self, rhs: Union[Timestream, Literal]) -> Timestream:
         """
         Create the logical disjunction of this Timestream and `rhs`.
 
         Parameters
         ----------
-        rhs : Arg
+        rhs : Union[Timestream, Literal]
             The Timestream or literal value to disjoin with.
 
         Returns
@@ -400,13 +397,13 @@ class Timestream(object):
         """
         return Timestream._call("not", self)
 
-    def eq(self, other: Arg) -> Timestream:
+    def eq(self, other: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream that is true if this is equal to `other`.
 
         Parameters
         ----------
-        other : Arg
+        other : Union[Timestream, Literal]
             The Timestream or literal value to compare to.
 
         Returns
@@ -416,13 +413,13 @@ class Timestream(object):
         """
         return Timestream._call("eq", self, other)
 
-    def ne(self, other: Arg) -> Timestream:
+    def ne(self, other: Union[Timestream, Literal]) -> Timestream:
         """
         Create a Timestream that is true if this is not equal to `other`.
 
         Parameters
         ----------
-        other : Arg
+        other : Union[Timestream, Literal]
             The Timestream or literal value to compare to.
 
         Returns
@@ -432,7 +429,7 @@ class Timestream(object):
         """
         return Timestream._call("neq", self, other)
 
-    def __getitem__(self, key: Arg) -> Timestream:
+    def __getitem__(self, key: Union[Timestream, Literal]) -> Timestream:
         """
         Index into the elements of a Timestream.
 
@@ -445,7 +442,7 @@ class Timestream(object):
 
         Parameters
         ----------
-        key : Arg
+        key : Union[Timestream, Literal]
             The key to index into the expression.
 
         Returns
@@ -687,7 +684,7 @@ class Timestream(object):
 
 
 def _aggregation(
-    op: str, input: Timestream, window: Optional["kt.Window"], *args: Optional[Arg]
+    op: str, input: Timestream, window: Optional["kt.Window"], *args: Union[Timestream, Literal]
 ) -> Timestream:
     """
     Create the aggregation `op` with the given `input`, `window` and `args`.
@@ -700,7 +697,7 @@ def _aggregation(
         The input to the aggregation.
     window : Optional[Window]
         The window to use for the aggregation.
-    *args : Optional[Arg]
+    *args : Union[Timestream, Literal]
         Additional arguments to provide before `input` and the flattened window.
 
     Returns


### PR DESCRIPTION
Get the type alias to render, along with links. Rename the type alias to `Literal` and use it just for the literals.