### PR TITLE
feat: add a `seconds since previous` function

### DIFF
--- a/sparrow-py/pysrc/sparrow_py/_timestream.py
+++ b/sparrow-py/pysrc/sparrow_py/_timestream.py
@@ -877,6 +877,22 @@ class Timestream(object):
         """
         return Timestream._call("shift_until", predicate, self)
 
+    def seconds_since_previous(self, n: int = 1) -> Timestream:
+        """
+        Create a Timestream containing the number of seconds since the previous
+        point in this Timestream.
+
+        Returns
+        -------
+        Timestream
+            Timestream containing the number of seconds since the previous point.
+        """
+        session = self._ffi_expr.session()
+        time_of_current = Timestream._call("time_of", self, session=session).cast(pa.int64())
+        time_of_previous = Timestream._call("time_of", self, session=session).lag(n).cast(pa.int64())
+        return  (time_of_current - time_of_previous) / 1e9
+
+
     def sum(self, *, window: Optional[kt.windows.Window] = None) -> Timestream:
         """
         Create a Timestream summing the values in the `window`.

--- a/sparrow-py/pytests/golden/seconds_since_test/test_seconds_since.jsonl
+++ b/sparrow-py/pytests/golden/seconds_since_test/test_seconds_since.jsonl
@@ -1,0 +1,6 @@
+{"_time":"1996-12-19T16:39:57.000","_subsort":0,"_key_hash":12960666915911099378,"_key":"A","time":"1996-12-19T16:39:57.000","seconds_since_previous":null,"seconds_since_previous_2":null}
+{"_time":"1996-12-19T16:39:58.000","_subsort":1,"_key_hash":2867199309159137213,"_key":"B","time":"1996-12-19T16:39:58.000","seconds_since_previous":null,"seconds_since_previous_2":null}
+{"_time":"1996-12-19T16:39:59.000","_subsort":2,"_key_hash":12960666915911099378,"_key":"A","time":"1996-12-19T16:39:59.000","seconds_since_previous":2.0,"seconds_since_previous_2":null}
+{"_time":"1996-12-19T16:40:00.000","_subsort":3,"_key_hash":12960666915911099378,"_key":"A","time":"1996-12-19T16:40:00.000","seconds_since_previous":1.0,"seconds_since_previous_2":3.0}
+{"_time":"1996-12-19T16:40:01.000","_subsort":4,"_key_hash":12960666915911099378,"_key":"A","time":"1996-12-19T16:40:01.000","seconds_since_previous":1.0,"seconds_since_previous_2":2.0}
+{"_time":"1996-12-19T16:40:02.000","_subsort":5,"_key_hash":12960666915911099378,"_key":"A","time":"1996-12-19T16:40:02.000","seconds_since_previous":1.0,"seconds_since_previous_2":2.0}

--- a/sparrow-py/pytests/seconds_since_test.py
+++ b/sparrow-py/pytests/seconds_since_test.py
@@ -1,0 +1,31 @@
+import pytest
+import sparrow_py as kt
+
+
+@pytest.fixture
+def source() -> kt.sources.CsvString:
+    content = "\n".join(
+        [
+            "time,key,m,n",
+            "1996-12-19T16:39:57,A,5,10",
+            "1996-12-19T16:39:58,B,24,3",
+            "1996-12-19T16:39:59,A,17,6",
+            "1996-12-19T16:40:00,A,,9",
+            "1996-12-19T16:40:01,A,12,",
+            "1996-12-19T16:40:02,A,,",
+        ]
+    )
+    return kt.sources.CsvString(content, time_column_name="time", key_column_name="key")
+
+
+def test_seconds_since(golden, source) -> None:
+    t = source.col("time")
+    golden.jsonl(
+        kt.record(
+            {
+                "time": t,
+                "seconds_since_previous": t.seconds_since_previous(),
+                "seconds_since_previous_2": t.seconds_since_previous(2),
+            }
+        )
+    )


### PR DESCRIPTION
Not quite the `seconds_since(other)` function we wanted, but this should encapsulate the following behavior at least
```
nanoseconds_since_previous: (time_of(Foo) as i64) - (((time_of(Foo) | lag(n)) as i64)
```