### PR TITLE
ref: remove signature modes

### DIFF
--- a/crates/sparrow-compiler/src/dfg.rs
+++ b/crates/sparrow-compiler/src/dfg.rs
@@ -264,7 +264,7 @@ impl Dfg {
                         );
                     }
                     Expression::Inst(InstKind::Simple(op)) => op
-                        .signature(sparrow_instructions::Mode::Plan)
+                        .signature()
                         .assert_valid_argument_count(children.len() - 1),
                     Expression::Inst(InstKind::FieldRef) => {
                         anyhow::ensure!(

--- a/crates/sparrow-compiler/src/dfg/const_eval.rs
+++ b/crates/sparrow-compiler/src/dfg/const_eval.rs
@@ -138,12 +138,7 @@ pub(super) fn evaluate_constant(
 
     let argument_types = args.iter().map(|i| i.data_type.clone().into()).collect();
     let argument_literals: Vec<_> = inputs.into_iter().map(Some).collect();
-    let result_type = typecheck_inst(
-        kind,
-        argument_types,
-        &argument_literals,
-        sparrow_instructions::Mode::Dfg,
-    )?;
+    let result_type = typecheck_inst(kind, argument_types, &argument_literals)?;
     let result_type = result_type.arrow_type().with_context(|| {
         format!(
             "Expected result of literal instruction to have concrete type, but got {result_type:?}"
@@ -219,13 +214,7 @@ mod tests {
             }
 
             let kind = InstKind::Simple(inst_op);
-            let inputs = vec![
-                ScalarValue::Null;
-                inst_op
-                    .signature(sparrow_instructions::Mode::Dfg)
-                    .parameters()
-                    .len()
-            ];
+            let inputs = vec![ScalarValue::Null; inst_op.signature().parameters().len()];
 
             if let Err(e) = super::evaluate_constant(&kind, inputs) {
                 println!("Failed to evaluate '{inst_op}': {e:?}");

--- a/crates/sparrow-compiler/src/plan/expression_to_plan.rs
+++ b/crates/sparrow-compiler/src/plan/expression_to_plan.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use sparrow_api::kaskada::v1alpha::DataType;
 use sparrow_api::kaskada::v1alpha::{expression_plan, ExpressionPlan};
 use sparrow_arrow::scalar_value::ScalarValue;
-use sparrow_instructions::{InstKind, Mode};
+use sparrow_instructions::InstKind;
 use sparrow_syntax::{ArgVec, FenlType};
 
 use crate::dfg::Expression;
@@ -97,11 +97,7 @@ fn infer_result_type(
         }
     }
 
-    let result_type = crate::types::instruction::typecheck_inst(
-        inst_kind,
-        argument_types,
-        &argument_literals,
-        Mode::Plan,
-    )?;
+    let result_type =
+        crate::types::instruction::typecheck_inst(inst_kind, argument_types, &argument_literals)?;
     DataType::try_from(&result_type).context("unable to encode result type")
 }

--- a/crates/sparrow-compiler/src/types/instruction.rs
+++ b/crates/sparrow-compiler/src/types/instruction.rs
@@ -5,7 +5,7 @@ use arrow::datatypes::{DataType, Field};
 use itertools::{izip, Itertools};
 use sparrow_arrow::scalar_value::ScalarValue;
 use sparrow_instructions::CastEvaluator;
-use sparrow_instructions::{InstKind, Mode};
+use sparrow_instructions::InstKind;
 use sparrow_syntax::{ArgVec, Collection, FenlType, Resolved};
 
 use crate::types::inference::validate_instantiation;
@@ -20,11 +20,10 @@ pub(crate) fn typecheck_inst(
     inst: &InstKind,
     argument_types: ArgVec<FenlType>,
     argument_literals: &[Option<ScalarValue>],
-    mode: Mode,
 ) -> anyhow::Result<FenlType> {
     match inst {
         InstKind::Simple(instruction) => {
-            let signature = instruction.signature(mode);
+            let signature = instruction.signature();
             let argument_types = Resolved::new(
                 Cow::Borrowed(signature.parameters().names()),
                 argument_types,


### PR DESCRIPTION
Signature modes are not necessary. They used to be necessary because we had a handful of varying signatures for aggregations to flatten window arguments, but that was since removed. 

