### PR TITLE
ci: re-install Kaskada when building docs

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -131,6 +131,7 @@ jobs:
           poetry env use 3.11
           source $(poetry env info --path)/bin/activate
           poetry install --with=docs
+          pip install 'kaskada[plot]>=0.6.0-a.0' --find-links dist --force-reinstall
           ls docs/source/_static
           sphinx-build docs/source docs/_build -j auto -W
           deactivate


### PR DESCRIPTION
Poetry install attempts to manage the virtualenv, so it uninstalls things it doesn't think are necessary, including `plotly`.