### PR TITLE
bug: fix normalization of versions when setting toml

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -54,7 +54,7 @@ jobs:
         if: github.event_name != 'release'
         run: |
           pip install tomlkit packaging
-          VERSION=$(python ../scripts/version.py get --normalize pyproject.toml project.version)
+          VERSION=$(python ../scripts/version.py get pyproject.toml project.version)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Determine version (release)
         if: github.event_name == 'release'
@@ -62,7 +62,6 @@ jobs:
           echo "GITHUB_REF=${GITHUB_REF}"
           VERSION=${GITHUB_REF#refs/tags/v}
           pip install tomlkit packaging
-          VERSION=$(python ../scripts/version.py normalize $VERSION)
           echo "VERSION=${VERSION}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Set version
@@ -120,7 +119,8 @@ jobs:
       - name: pytest and mypy
         if: matrix.target != 'arm64'
         run: |
-          WHEEL="dist/kaskada-${{ needs.version.outputs.version }}-cp38-abi3-${{ matrix.wheel_suffix }}.whl"
+          VERSION=$(python ../scripts/version.py normalize ${{ needs.version.outputs.version }})
+          WHEEL="dist/kaskada-${VERSION}-cp38-abi3-${{ matrix.wheel_suffix }}.whl"
           echo "WHEEL:${WHEEL}"
           for V in 3.9 3.10 3.11; do
             echo "::group::Install for Python $V"
@@ -183,7 +183,8 @@ jobs:
           echo "::group::Install for Python 3.11"
           source $(poetry env info --path)\\Scripts\\activate
           poetry install --only=test --only=typecheck
-          WHEEL="dist/kaskada-${{ needs.version.outputs.version }}-cp38-abi3-win_amd64.whl"
+          VERSION=$(python ../scripts/version.py normalize ${{ needs.version.outputs.version }})
+          WHEEL="dist/kaskada-${VERSION}-cp38-abi3-win_amd64.whl"
           echo "WHEEL:${WHEEL}"
           pip install ${WHEEL} --force-reinstall
           echo "::endgroup::"
@@ -245,7 +246,8 @@ jobs:
       - name: pytest and mypy (Linux x86_64)
         if: matrix.target == 'x86_64'
         run: |
-          WHEEL="dist/kaskada-${{ needs.version.outputs.version }}-cp38-abi3-manylinux_2_28_${{ matrix.target }}.whl"
+          VERSION=$(python ../scripts/version.py normalize ${{ needs.version.outputs.version }})
+          WHEEL="dist/kaskada-${VERSION}-cp38-abi3-manylinux_2_28_${{ matrix.target }}.whl"
           echo "WHEEL:${WHEEL}"
           for V in 3.9 3.10 3.11; do
             echo "::group::Install for Python $V"

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -18,7 +18,7 @@ def get_value_from_toml(file_path: str, toml_path: str | List[str]) -> str:
     return str(temp)  # Convert value to string in case it's a number or boolean
 
 
-def update_version_in_data(data: Dict, version: str, toml_paths: List[str]) -> None:
+def set_version_in_data(data: Dict, version: str, toml_paths: List[str]) -> None:
     """Update the version number in a data dictionary (parsed TOML) at multiple paths."""
     for path in toml_paths:
         temp = data
@@ -28,9 +28,9 @@ def update_version_in_data(data: Dict, version: str, toml_paths: List[str]) -> N
         temp[path[-1]] = version
 
 
-def update_versions(entries: List[str], version: str) -> None:
+def set_versions(entries: List[str], version: str) -> None:
     """Update the version number in the given entries."""
-        # Dictionary to hold the paths for each file
+    # Dictionary to hold the paths for each file
     file_paths_dict = defaultdict(list)
 
     for entry in entries:
@@ -48,7 +48,7 @@ def update_versions(entries: List[str], version: str) -> None:
         with open(file_path, 'r') as f:
             data = tomlkit.parse(f.read())
 
-        update_version_in_data(data, version, paths)
+        set_version_in_data(data, version, paths)
 
         with open(file_path, 'w') as f:
             f.write(dumps(data))
@@ -85,7 +85,7 @@ def main() -> None:
             version = normalize_version(version)
         print(version)
     elif args.command == "set":
-        update_versions(args.entries, args.version)
+        set_versions(args.entries, args.version)
     elif args.command == "normalize":
         print(normalize_version(args.version))
     else:


### PR DESCRIPTION
I _believe_ we only want the normalized versions when using them in the wheels. When we set them in the toml files, we want to retain the non-normalized format. 