### PR TITLE
comment out arm64 wheel target

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -79,8 +79,8 @@ jobs:
         include:
           - target: x86_64
             wheel_suffix: macosx_11_0_x86_64
-          - target: arm64
-            wheel_suffix: macosx_11_0_arm64
+          # - target: arm64
+          #   wheel_suffix: macosx_11_0_arm64
           - target: universal2
             wheel_suffix: macosx_11_0_x86_64.macosx_11_0_arm64.macosx_11_0_universal2
     steps:


### PR DESCRIPTION
arm64 wheel build is current failing: https://github.com/kaskada-ai/kaskada/actions/runs/6092183627/job/16529911562

The universal2 target binary should work for now, but the arm64 should be a smaller binary for that specific architecture. 

Commenting out for now to let build pass. 