### PR TITLE
bug: fix shift to batch bounds

### DIFF
--- a/python/pytests/golden/shift_by_test/test_filter_to_shift.jsonl
+++ b/python/pytests/golden/shift_by_test/test_filter_to_shift.jsonl
@@ -1,0 +1,3 @@
+{"_time":"2023-08-11T14:03:35.000000000","_key":"Project","thread_ts":null,"ts":1691762610.0,"channel":"Project"}
+{"_time":"2023-08-11T14:03:45.000000000","_key":"Project","thread_ts":null,"ts":1691762620.0,"channel":"Project"}
+{"_time":"2023-08-11T14:03:55.000000000","_key":"Project","thread_ts":null,"ts":1691762630.0,"channel":"Project"}

--- a/python/pytests/shift_by_test.py
+++ b/python/pytests/shift_by_test.py
@@ -75,7 +75,8 @@ async def test_shift_collect(source, golden) -> None:
 
 
 
+# Regression test for https://github.com/kaskada-ai/kaskada/issues/726
 async def test_filter_to_shift(filter_source, golden) -> None:
     messages = filter_source.filter(filter_source.col("thread_ts").is_null())
-    messages = messages.shift_by(timedelta(microseconds=0.001))
+    messages = messages.shift_by(timedelta(seconds=5))
     golden.jsonl(messages)

--- a/python/pytests/shift_by_test.py
+++ b/python/pytests/shift_by_test.py
@@ -20,6 +20,23 @@ async def source() -> kd.sources.CsvString:
     )
 
 
+@pytest.fixture(scope="module")
+async def filter_source() -> kd.sources.CsvString:
+    content = "\n".join(
+        [
+            "thread_ts,ts,channel",
+            "null,1691762610.0,Project",
+            "null,1691762620.0,Project",
+            "null,1691762630.0,Project",
+            "1691762650.0,1691762650.0,Project",
+            "1691762650.0,1691762660.0,Project",
+        ]
+    )
+    return await kd.sources.CsvString.create(
+        content, time_column="ts", key_column="channel", time_unit="s"
+    )
+
+
 async def test_shift_by_timedelta(source, golden) -> None:
     time = source.col("time")
     golden.jsonl(
@@ -55,3 +72,10 @@ async def test_shift_collect(source, golden) -> None:
             }
         )
     )
+
+
+
+async def test_filter_to_shift(filter_source, golden) -> None:
+    messages = filter_source.filter(filter_source.col("thread_ts").is_null())
+    messages = messages.shift_by(timedelta(microseconds=0.001))
+    golden.jsonl(messages)

--- a/python/pytests/shift_by_test.py
+++ b/python/pytests/shift_by_test.py
@@ -74,7 +74,6 @@ async def test_shift_collect(source, golden) -> None:
     )
 
 
-
 # Regression test for https://github.com/kaskada-ai/kaskada/issues/726
 async def test_filter_to_shift(filter_source, golden) -> None:
     messages = filter_source.filter(filter_source.col("thread_ts").is_null())


### PR DESCRIPTION
Sets the shift to's pending set to empty if no rows exist. 

See #726 for details