### PR TITLE
feat: support lists in spread zip

### DIFF
--- a/crates/sparrow-arrow/src/concat_take.rs
+++ b/crates/sparrow-arrow/src/concat_take.rs
@@ -1,4 +1,4 @@
-use arrow_array::{ArrayRef, UInt32Array};
+use arrow_array::{Array, ArrayRef, UInt32Array};
 
 /// Concatenates two arrays and then takes the values at the given indices.
 ///
@@ -6,8 +6,8 @@ use arrow_array::{ArrayRef, UInt32Array};
 /// the indices are solely in the first or second array and then taking the values from
 /// the respective arrays.
 pub fn concat_take(
-    array1: &ArrayRef,
-    array2: &ArrayRef,
+    array1: &dyn Array,
+    array2: &dyn Array,
     indices: &UInt32Array,
 ) -> anyhow::Result<ArrayRef> {
     let combined = arrow_select::concat::concat(&[array1, array2])?;

--- a/crates/sparrow-runtime/src/execute/operation/spread_zip.rs
+++ b/crates/sparrow-runtime/src/execute/operation/spread_zip.rs
@@ -359,7 +359,7 @@ mod tests {
 
         let result = spread_zip(&mask, &truthy, &falsy).unwrap();
         let result = result.as_primitive::<UInt32Type>();
-        assert_eq!(result.values(), &[1, 4, 0, 2]);
+        assert_eq!(result.values(), &[1, 3, 0, 2, 4]);
     }
 
     #[test]


### PR DESCRIPTION
Uses the `concat_take` kernel to implement spread zip for lists, which should nested types as well. 

We probably could simplify the `spread_struct` by using concat take too, and maybe even use that for primitives if it's performant. 

Closes #788 