### PR TITLE
Revert CI changes from #835

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -232,6 +232,7 @@ jobs:
           poetry env use 3.11
           source $(poetry env info --path)/bin/activate
           poetry install --with=docs
+          pip install ${WHEEL} --force-reinstall
           cd docs
           python _scripts/lint_reference.py
           deactivate
@@ -241,6 +242,8 @@ jobs:
         run: |
           poetry env use 3.11
           source $(poetry env info --path)/bin/activate
+          poetry install --with=docs
+          pip install ${WHEEL} --force-reinstall
           cd docs
           python _scripts/gen_reference.py
           python -m quartodoc interlinks


### PR DESCRIPTION
CI changes in #835 are possible suspects of causing failures like https://github.com/kaskada-ai/kaskada/actions/runs/6773940166/job/18413889767.

Reverting to see.